### PR TITLE
Add map run flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ mono_crash.*.json
 .claude/
 .superpowers/
 docs/superpowers/
+.worktrees/
 
 # Python tooling
 .venv/

--- a/docs/design.md
+++ b/docs/design.md
@@ -248,7 +248,7 @@ The complete demo experience showcasing all core systems across multiple rounds.
 
 #### Progression
 
-- 5–7 rounds with escalating blinds.
+- 10 map levels with escalating blinds.
 - Flea market evolution — rarer faces and powerful modifiers in later rounds.
 - Win/loss conditions — survive all rounds to win; losing has consequences (lost dice, reduced budget).
 
@@ -273,7 +273,7 @@ Self-contained demo: multiple rounds of shopping → dice customization → comb
 | Flea Market | Fixed catalogue, flat coin budget | Randomized stock, scaling prices, rarity tiers |
 | Items | ~10–12 items: dice, faces, modifiers | Large pool, synergies, conditional modifiers |
 | Combat | Roll + reroll, Yahtzee combos, single target score | Escalating blinds, rich modifier interactions |
-| Progression | Single round | 5–7 rounds, persistent inventory, difficulty scaling |
+| Progression | Single round | 10-level map run, persistent inventory, difficulty scaling |
 | Polish | Placeholder art, no sound | Animations, SFX, music, tutorial |
 
 ---
@@ -378,7 +378,7 @@ graph LR
     Modifiers --> TotalPower
 ```
 
-**Design intent:** channels 1 and 2 alone should be enough to clear rounds 1–4. Rounds 5–7 require channel 3 (modifier synergies), forcing the player to think beyond face values and into build architecture.
+**Design intent:** channels 1 and 2 alone should be enough to clear early rounds. Later rounds require channel 3 (modifier synergies), forcing the player to think beyond face values and into build architecture.
 
 ### Power vs. Blinds
 
@@ -403,7 +403,7 @@ The shop's item pool shifts across rounds to support the power curve:
 | 1–2 | Common faces, basic dice | 50–60 coins | Build foundation — high-value faces, extra dice |
 | 3–4 | Uncommon faces, first modifiers | 70–90 coins | Specialize — commit to a combo archetype |
 | 5–6 | Rare faces, powerful modifiers | 100–130 coins | Synergize — stack multipliers, fine-tune |
-| 7 | No shop (final round) | — | Prove the build — no more preparation |
+| Final level | No shop | — | Prove the build — no more preparation |
 
 Prices scale with rarity: common faces cost 4–10 coins, uncommon 12–18, rare 20–30. Budget grows faster than common prices but slower than rare prices, forcing the player to choose between many small upgrades or one powerful item.
 

--- a/docs/plans/2026-05-03-map-screen-design.md
+++ b/docs/plans/2026-05-03-map-screen-design.md
@@ -346,3 +346,70 @@ After `end_run()`, MainMenu's `_ready()` checks `GameManager.last_run_result`. I
 - Multi-chapter (multiple maps per run, escalating between them).
 - Movement animations and richer map visuals.
 - Run statistics and meta-progression.
+
+---
+
+## Addendum (2026-05-03): Reconciliation With Existing Codebase
+
+After reviewing the actual `scripts/autoload/game_manager.gd`, the design is reconciled with existing code as follows. The high-level architecture (Approach A: new `Phase.MAP`, `current_run` field, map screen + generator + state) is unchanged. The differences below take precedence over the original sections where they overlap.
+
+### Reuse `current_round` as the Progression Counter
+
+The original design proposed a new `combats_completed` field. This is replaced by reusing the existing `GameManager.current_round`. Rationale: `current_round` is already initialized in `_reset_run_state`, advanced by `advance_round()` (which also grants the coin reward and recomputes `target_score`), and serialized in save/load. Introducing a parallel counter would duplicate state and create two sources of truth for blind difficulty.
+
+Concretely:
+
+- `RunState` does **not** carry a combats counter. Progression is read from `GameManager.current_round`.
+- After a victorious COMBAT or BOSS map node, `complete_current_node()` calls the existing `advance_round()` logic for reward + `target_score` bump. The transition target (Map vs. FleaMarket vs. end_run) is decided by `complete_current_node()`, not by `advance_round()` itself — see "Splitting `advance_round`" below.
+- Boss blind multiplier is applied on top of `target_score` only when entering the BOSS node, by `enter_map_node()`.
+
+### Splitting `advance_round`
+
+Current `advance_round()` does two things: (a) grant reward and bump `target_score`, (b) transition to `Phase.FLEA_MARKET`. For a run, the destination phase depends on context (next map node, end of run, or — outside any run — keep legacy behavior). The fix:
+
+- Extract the reward + target bump into a private helper, e.g. `_apply_round_advance()`.
+- `advance_round()` keeps its current public signature and behavior for non-run callers (legacy single-round flow / loaded saves with no run): calls `_apply_round_advance()` then `_change_phase(Phase.FLEA_MARKET)`.
+- `complete_current_node()` (new) calls `_apply_round_advance()` directly, then decides next phase from run state.
+
+### Onboarding = Existing First Combat
+
+The original spec described an "onboarding shop / onboarding combat" with `current_node_id == -1`. In the actual codebase this is exactly the existing first round (`MainMenu → FleaMarket → Combat`), optionally preceded by the tutorial intro combat. No new "onboarding" methods are introduced. Instead:
+
+- `start_game()` (existing) is the entry point; it now also creates `current_run = MapGenerator.generate(...)` so a run is active from the start. The generated map is not visible until the first real combat completes.
+- The first FleaMarket → Combat cycle stays as it is. `CombatScreen` on victory calls `complete_current_node()`. Because `current_run.current_node_id == -1`, that call routes to `Phase.MAP` (instead of the legacy FleaMarket loop).
+- The earlier `complete_onboarding_shop()` method is **not** added — the existing FleaMarket "Combat" button keeps calling `go_to_combat()` for the first cycle.
+
+### Save / Load: Run Is Not Persisted
+
+The map and run state are explicitly excluded from save/load.
+
+- `build_save_data` / `apply_save_data` are **not** changed to include `current_run`, `last_run_result`, or any map data.
+- On load, `current_run` is `null` and `last_run_result` is `null`. The game resumes in the legacy single-round flow at the saved phase (typically `FLEA_MARKET`).
+- This preserves backwards compatibility with v2 saves and matches the "run save/load is future work" non-goal.
+- Closing the game mid-run loses the run. This is acceptable for the first iteration.
+
+### Abandoning a Run
+
+If the player returns to the main menu mid-run via an explicit "back to menu" / pause-quit action (not a combat defeat), this is an **abandon**, not a defeat:
+
+- `current_run` is set to `null`.
+- `last_run_result` is **not** populated.
+- `ResultsOverlay` does **not** show on the next MainMenu visit.
+
+`ResultsOverlay` only appears after `end_run(victory: bool)` is called from a real combat outcome (boss victory or mid-run defeat).
+
+### `last_run_result` Is In-Memory Only
+
+`last_run_result` is a transient field. It is not serialized into the save file. If the player quits the game after seeing the results overlay but before pressing Continue, the overlay does not reappear on next launch.
+
+### Updated Method List on `GameManager`
+
+The final method additions on `GameManager` for this slice are:
+
+- `enter_map_node(node_id: int) -> void`
+- `complete_current_node() -> void`
+- `end_run(victory: bool) -> void`
+- `abandon_run() -> void` (new — called from "back to menu" affordances when in a run)
+- `_apply_round_advance() -> void` (private helper extracted from `advance_round`)
+
+`start_game()` is modified (not replaced) to initialize `current_run`. `advance_round()` is refactored to call `_apply_round_advance()` then transition to `FLEA_MARKET`, preserving its public behavior for non-run callers.

--- a/docs/plans/2026-05-03-map-screen-design.md
+++ b/docs/plans/2026-05-03-map-screen-design.md
@@ -1,0 +1,348 @@
+# Map Screen — Roguelike Run Structure
+
+**Date:** 2026-05-03
+**Status:** Design approved, ready for planning
+
+## Summary
+
+Add a 4th top-level screen — **Map** — that turns the existing FleaMarket and Combat screens into nodes of a single run. The player's first round stays unchanged (FleaMarket → Combat) for onboarding, then a branching map opens. The player picks a path through ~5–7 nodes (Combat or Shop), ending in a Boss Combat. Victory or defeat returns to MainMenu via a results overlay.
+
+This is the smallest slice that delivers a roguelike meta-loop: route choice, escalating risk, and a defined run boundary.
+
+## Goals
+
+- Introduce route-choice gameplay on top of the existing FleaMarket/Combat loop.
+- Reuse existing screens as node types — no new combat or shop logic.
+- Define a clean run lifecycle: `start_run → nodes → end_run`, with results visible to the player.
+- Stay scoped to one well-bounded slice; leave richer roguelike features for later iterations.
+
+## Non-Goals (Future Work)
+
+- Additional node types: Elite, Event, Treasure, Mystery (`?`).
+- Per-node reward picks (STS-style "choose 1 of 3").
+- Pre-shown blind values per node (route planning by exact difficulty).
+- Save/load of an in-progress run.
+- Multi-chapter runs (one map = one run).
+- Animations of player movement between nodes.
+- Run statistics / persistent meta-progression.
+- Visual themes per chapter.
+
+---
+
+## Architecture (Approach A)
+
+`GameManager` gains a new phase and owns the active run. The map screen and run state are pure additions; FleaMarket and Combat screens are minimally adapted to ask `GameManager` what to do on exit instead of hardcoding their next phase.
+
+### New Files
+
+```
+scenes/map/
+  map_screen.tscn          # map screen root
+  map_screen.gd            # renders nodes/edges, forwards clicks to GameManager
+  map_node_button.tscn     # single node button (Combat / Shop / Boss)
+  map_node_button.gd
+
+scripts/map/
+  run_state.gd             # RefCounted: nodes, current node, combats_completed, seed
+  map_generator.gd         # RefCounted: generate(seed) -> RunState
+  map_node.gd              # RefCounted: id, type, depth, next_ids
+```
+
+### Modified Files
+
+- `scripts/autoload/game_manager.gd`
+  - Add `Phase.MAP`.
+  - Add `current_run: RunState` and `last_run_result: Dictionary` (or null).
+  - Add methods: `start_run()`, `complete_onboarding_shop()`, `enter_map_node(node_id: int)`, `complete_current_node()`, `end_run(victory: bool)`.
+- `scenes/main_menu/main_menu.gd`
+  - On `_ready`, if `GameManager.last_run_result != null`, show ResultsOverlay.
+  - Start button calls `GameManager.start_run()` instead of going straight to FleaMarket.
+- `scenes/flea_market/flea_market_screen.gd`
+  - Continue/Combat button branches:
+    - If `current_run.current_node_id == -1` (onboarding shop): call `complete_onboarding_shop()`.
+    - Else (shop node on map): call `complete_current_node()`.
+  - Button label switches between "Combat" (onboarding) and "Continue" (map shop node).
+- `scenes/combat/combat_screen.gd`
+  - On victory: `GameManager.complete_current_node()`.
+  - On defeat: `GameManager.end_run(false)`.
+- `resources/data/map_config.json` (new data file)
+  - Map shape parameters and boss multiplier.
+
+### Module Boundaries
+
+- `RunState` — pure data container. No logic beyond derived getters (e.g. `available_node_ids()`).
+- `MapGenerator` — pure function: `generate(seed: int, config: Dictionary) -> RunState`. No global state, no autoloads.
+- `MapNode` — pure data: `id`, `type` (enum: COMBAT, SHOP, BOSS), `depth`, `next_ids: Array[int]`.
+- `MapScreen` — UI only. Reads `GameManager.current_run`, renders, emits clicks back to `GameManager`. No run logic.
+- `GameManager` — orchestrator. Owns `current_run`, performs phase transitions.
+
+---
+
+## Run Flow
+
+```
+MainMenu
+  └─ [Start] → start_run()
+              → Phase.FLEA_MARKET (onboarding shop, current_node_id = -1)
+
+FleaMarket (onboarding)
+  └─ [Combat] → complete_onboarding_shop()
+              → Phase.COMBAT (combats_completed = 0)
+
+Combat (onboarding)
+  └─ victory → complete_current_node()
+              → Phase.MAP (combats_completed = 1)
+  └─ defeat  → end_run(false) → ResultsOverlay → MainMenu
+
+Map
+  └─ click available node → enter_map_node(id)
+       ├─ COMBAT / BOSS → Phase.COMBAT
+       └─ SHOP          → Phase.FLEA_MARKET
+
+Combat (map node)
+  └─ victory:
+      ├─ if BOSS → end_run(true) → ResultsOverlay → MainMenu
+      └─ else    → Phase.MAP (combats_completed += 1)
+  └─ defeat → end_run(false) → ResultsOverlay → MainMenu
+
+FleaMarket (map node)
+  └─ [Continue] → complete_current_node() → Phase.MAP
+```
+
+### `GameManager` Method Contracts
+
+```gdscript
+func start_run() -> void:
+    # Called from MainMenu Start button.
+    # Generates a new run, resets coins/dice_bag, enters Phase.FLEA_MARKET.
+    current_run = MapGenerator.generate(randi(), DataManager.get_map_config())
+    coins = STARTING_COINS
+    dice_bag = DiceBag.new()
+    last_run_result = null
+    _set_phase(Phase.FLEA_MARKET)
+
+func complete_onboarding_shop() -> void:
+    # Called from FleaMarket when current_node_id == -1.
+    # Transitions to onboarding combat (no node tracking yet).
+    _set_phase(Phase.COMBAT)
+
+func enter_map_node(node_id: int) -> void:
+    # Called from MapScreen on click.
+    # Validates node_id is in current_run.available_node_ids(); warns and returns if not.
+    # Sets current_node_id, transitions to COMBAT or FLEA_MARKET by node type.
+
+func complete_current_node() -> void:
+    # Called from CombatScreen on victory or FleaMarket on Continue (map shop node).
+    # If current node is COMBAT: combats_completed += 1, transition to MAP.
+    # If current node is BOSS: combats_completed += 1, end_run(true).
+    # If current node is SHOP: transition to MAP.
+    # If current_node_id == -1 (onboarding combat completion): combats_completed = 1, transition to MAP.
+
+func end_run(victory: bool) -> void:
+    # Stores last_run_result, clears current_run, returns to MainMenu.
+    last_run_result = {
+        "victory": victory,
+        "combats": current_run.combats_completed,
+        "total_score": total_score,
+        "coins": coins,
+    }
+    current_run = null
+    _set_phase(Phase.MAIN_MENU)
+```
+
+---
+
+## Map Structure & Generation
+
+### Config (`resources/data/map_config.json`)
+
+```json
+{
+  "depth": 6,
+  "min_nodes_per_level": 1,
+  "max_nodes_per_level": 3,
+  "shop_probability": 0.3,
+  "max_consecutive_shops": 2,
+  "boss_blind_multiplier": 1.5
+}
+```
+
+Validation at load time (`DataManager`): `depth >= 2`, all probabilities in `[0, 1]`, `min <= max` for node counts. On invalid values: `push_error`, fall back to defaults.
+
+### Algorithm
+
+`MapGenerator.generate(seed: int, config: Dictionary) -> RunState`:
+
+1. Seed an RNG with `seed`.
+2. Create level 0 (virtual start; no node, just an anchor for `current_node_id == -1`).
+3. For each level `L` from 1 to `depth - 1`:
+   - Pick node count uniformly in `[min_nodes_per_level, max_nodes_per_level]`.
+   - For each node, assign type: SHOP with `shop_probability`, else COMBAT.
+4. Create level `depth` with exactly one BOSS node.
+5. Connect edges:
+   - Each node at level `L` connects to 1–2 nodes at level `L+1`.
+   - Connections are chosen so edges, when nodes are laid out vertically by index, do not cross.
+   - Every node at levels `1..depth-1` must have at least one outgoing edge.
+   - Every node at levels `1..depth` must have at least one incoming edge (i.e. reachable from start).
+6. Post-process `max_consecutive_shops`: enumerate paths from any level-1 node to the boss (DFS); if any path has more than `max_consecutive_shops` SHOP nodes in a row, flip excess SHOPs to COMBAT.
+
+### `RunState`
+
+```
+nodes: Dictionary[int, MapNode]   # node_id -> MapNode
+current_node_id: int              # -1 initially (before any node entered)
+combats_completed: int            # increments after COMBAT and BOSS nodes (and after onboarding combat)
+seed: int                         # for reproducibility / debugging
+```
+
+Derived getters:
+- `available_node_ids() -> Array[int]`:
+  - If `current_node_id == -1`: return all level-1 node ids.
+  - Else: return `nodes[current_node_id].next_ids`.
+
+### `MapNode`
+
+```
+id: int
+type: NodeType   # enum { COMBAT, SHOP, BOSS }
+depth: int
+next_ids: Array[int]
+```
+
+### Node Reachability
+
+After generation, every node at levels `1..depth` must be reachable from a level-1 node, and every node at levels `1..depth-1` must reach the boss. The generator must guarantee this; tests assert it.
+
+---
+
+## Blinds
+
+The existing combat blind formula is a function of "round number". This design replaces "round number" with `current_run.combats_completed`:
+
+```gdscript
+var combats_done := 0
+if GameManager.current_run != null:
+    combats_done = GameManager.current_run.combats_completed
+target_score = base_blind * blind_growth_curve(combats_done)
+```
+
+For the BOSS node, multiply the result by `boss_blind_multiplier` from `map_config.json`.
+
+The existing growth curve (whatever is in current Combat code) is preserved; only the input source changes. Pre-existing tests for the growth curve continue to pass.
+
+---
+
+## UI
+
+### `MapScreen` Layout
+
+```
+Control root → Background → MarginContainer → VBoxContainer:
+  ├─ TopBar: MenuButton, "MAP" title, CoinLabel
+  ├─ MapContainer (Control with custom _draw for edges)
+  │    └─ MapNodeButton instances, positioned by:
+  │         x = depth * level_spacing_px
+  │         y = (index_in_level - level_size / 2.0) * node_spacing_px
+  └─ BottomBar: "Combats completed: X / total" subtitle
+```
+
+`MapContainer._draw()` iterates all nodes, draws a line from each to its `next_ids`. Edge color:
+- Bright (highlighted) for edges leaving `current_node_id` (or all level-1 incoming edges if `current_node_id == -1`).
+- Dimmed gray for all other edges.
+
+### `MapNodeButton`
+
+- Icon by type:
+  - COMBAT: sword (placeholder)
+  - SHOP: coin (placeholder)
+  - BOSS: skull (placeholder)
+- States:
+  - `available`: full color, clickable.
+  - `locked`: grayed out, not clickable.
+  - `completed`: dimmed with checkmark.
+- Click on `available` → emits `node_clicked(id)` → `MapScreen` calls `GameManager.enter_map_node(id)`.
+
+### Results Overlay
+
+After `end_run()`, MainMenu's `_ready()` checks `GameManager.last_run_result`. If non-null, shows an overlay:
+
+```
+┌─────────────────────────────┐
+│   VICTORY  /  DEFEATED      │
+│                             │
+│   Combats won: X            │
+│   Total score: Y            │
+│   Coins remaining: Z        │
+│                             │
+│         [Continue]          │
+└─────────────────────────────┘
+```
+
+`[Continue]` clears `last_run_result` and dismisses the overlay. Player can then press `[Start]` for a new run.
+
+---
+
+## Testing
+
+### Unit Tests (`tests/unit/`)
+
+- `test_map_generator.gd`:
+  - Map has `depth + 1` levels (level 0 is the virtual start).
+  - Level `depth` has exactly one node, type BOSS.
+  - All nodes at levels `1..depth-1` are COMBAT or SHOP.
+  - Every non-boss node has at least one outgoing edge.
+  - Every node at levels `1..depth` is reachable from a level-1 node (BFS check).
+  - Same seed → identical map (determinism).
+  - On every path from a level-1 node to the boss, no run of SHOP nodes exceeds `max_consecutive_shops`.
+
+- `test_run_state.gd`:
+  - `current_node_id == -1` initially; `available_node_ids()` returns all level-1 nodes.
+  - After setting `current_node_id` to a non-leaf node, `available_node_ids()` equals that node's `next_ids`.
+
+### Integration Tests (`tests/integration/`)
+
+- `test_run_flow.gd`:
+  - `start_run()` → phase FLEA_MARKET, `current_run != null`, `combats_completed == 0`, `current_node_id == -1`.
+  - `complete_onboarding_shop()` → phase COMBAT.
+  - Simulate combat victory via `complete_current_node()` while `current_node_id == -1` → phase MAP, `combats_completed == 1`.
+  - `enter_map_node(valid_id)` → correct phase by node type; `current_node_id` updated.
+  - `enter_map_node(invalid_id)` → no phase change, warning emitted.
+  - Victory on BOSS node via `complete_current_node()` → `end_run(true)`, `last_run_result.victory == true`, `current_run == null`, phase MAIN_MENU.
+  - Defeat mid-map via `end_run(false)` → `last_run_result.victory == false`, `current_run == null`, phase MAIN_MENU.
+
+### Smoke Tests (`tests/smoke/`)
+
+- `test_map_screen_smoke.gd`: instantiate `MapScreen` with a fixture `RunState` (1 level + boss, ~3 nodes total) and assert it loads without errors.
+
+### Validation Pipeline
+
+`make test` picks up new tests automatically (GUT scans `tests/`). No Makefile changes required. `make static-check`, `make lint`, `make format-check` apply to new files unchanged.
+
+---
+
+## Error Handling & Edge Cases
+
+- **Click on locked node:** `GameManager.enter_map_node()` validates `node_id ∈ current_run.available_node_ids()`. On mismatch: `push_warning`, return without changing state. UI also marks locked nodes non-clickable as a first-line defense.
+- **`current_run == null` in `complete_current_node()`:** Possible only via misuse (e.g. test scene). `push_warning`, early return.
+- **Invalid `map_config.json`:** Validate at load; on failure `push_error` and use defaults.
+- **Game closed mid-run:** Run is lost. Save/load is explicit future work.
+- **Generator fails reachability post-condition:** assert in debug builds; in release, regenerate with a different seed (bounded to e.g. 5 retries) before raising an error.
+
+---
+
+## Open Questions (None Blocking)
+
+- Exact placeholder art for node icons — can use Godot built-in icons or simple ColorRects until art is ready.
+- Edge rendering style (straight line vs. bezier) — pick whichever looks acceptable; not load-bearing.
+
+---
+
+## Future Work (Recap)
+
+- Pre-shown per-node blinds (route planning).
+- Elite / Event / Treasure / Mystery node types.
+- STS-style post-combat reward picks.
+- Run save/load.
+- Multi-chapter (multiple maps per run, escalating between them).
+- Movement animations and richer map visuals.
+- Run statistics and meta-progression.

--- a/docs/plans/2026-05-03-map-screen-implementation.md
+++ b/docs/plans/2026-05-03-map-screen-implementation.md
@@ -1,0 +1,1816 @@
+# Map Screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 4th top-level screen — Map — that turns existing FleaMarket and Combat screens into nodes of a single roguelike run, ending in a Boss combat.
+
+**Architecture:** New `Phase.MAP` and `current_run` field on `GameManager`. New screens/scripts: `MapScreen`, `MapNodeButton`, `RunState`, `MapGenerator`, `MapNode`. Existing `advance_round()`, `end_combat()`, and `FleaMarket` "Combat" button become run-aware: they consult `current_run` to decide whether to transition to `Phase.MAP` or fall through to legacy single-round flow. `current_run` is in-memory only — not serialized into save data. Reuses existing `current_round` for blind progression rather than introducing a parallel counter.
+
+**Tech Stack:** Godot 4.6, GDScript, GUT for tests, JSON config under `resources/data/`.
+
+**Spec:** `docs/plans/2026-05-03-map-screen-design.md` (read this first; the addendum at the end takes precedence over the original sections where they overlap).
+
+---
+
+## File Structure
+
+### New files
+
+```
+resources/data/
+  map_config.json                       # depth, node count bounds, shop probability, max consecutive shops, boss multiplier
+
+scripts/map/
+  map_node.gd                           # RefCounted: { id, type, depth, next_ids }
+  run_state.gd                          # RefCounted: { nodes, current_node_id, seed, available_node_ids() }
+  map_generator.gd                      # RefCounted: generate(seed, config) -> RunState
+
+scenes/map/
+  map_node_button.tscn                  # one node button (icon + state)
+  map_node_button.gd
+  map_screen.tscn                       # map screen root
+  map_screen.gd                         # renders nodes/edges, forwards clicks
+
+tests/unit/
+  test_map_node.gd
+  test_run_state.gd
+  test_map_generator.gd
+
+tests/integration/
+  test_run_flow.gd
+
+tests/smoke/
+  test_map_screen_smoke.gd
+```
+
+### Modified files
+
+```
+scripts/autoload/game_manager.gd        # Phase.MAP, current_run, last_run_result; route-aware end_combat / advance_round; new methods enter_map_node, complete_current_node, end_run, abandon_run
+scripts/autoload/data_manager.gd        # load + validate map_config.json
+scenes/main_menu/main_menu.gd           # show ResultsOverlay if last_run_result is set
+scenes/combat/combat_screen.gd          # surface "back to menu" affordance as abandon_run when in a run (no other code change — end_combat dispatch is in GameManager)
+scenes/flea_market/flea_market_screen.gd # rename Combat button to Continue and route through complete_current_node when in a SHOP map node
+project.godot                           # nothing to change (no new autoload); GameManager already exists
+```
+
+### Module boundaries (recap)
+
+- `MapNode`, `RunState` — pure data containers; no side effects.
+- `MapGenerator.generate(seed, config)` — pure function; no globals, no autoloads.
+- `MapScreen` — UI; reads `GameManager.current_run`, routes clicks back to `GameManager.enter_map_node(id)`.
+- `GameManager` — orchestrator; owns `current_run` and `last_run_result`; performs phase transitions.
+
+### `Phase` enum after this slice
+
+```gdscript
+enum Phase { MAIN_MENU, FLEA_MARKET, DICE_SELECT, COMBAT, MAP }
+```
+
+`MAP` is appended at the end so existing save files (which serialize phase by name via `Phase.keys()[…]`) continue to deserialize without ambiguity. Saves never contain `MAP` (we don't persist runs).
+
+---
+
+## Task 1: Create the `MapNode` data class
+
+**Files:**
+- Create: `scripts/map/map_node.gd`
+- Test: `tests/unit/test_map_node.gd`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_map_node.gd`:
+
+```gdscript
+extends GutTest
+
+const MapNode := preload("res://scripts/map/map_node.gd")
+
+
+func test_constructs_with_fields() -> void:
+	var node := MapNode.new(7, MapNode.NodeType.COMBAT, 3, [9, 10] as Array[int])
+	assert_eq(node.id, 7)
+	assert_eq(node.type, MapNode.NodeType.COMBAT)
+	assert_eq(node.depth, 3)
+	assert_eq(node.next_ids, [9, 10] as Array[int])
+
+
+func test_node_type_values_distinct() -> void:
+	assert_ne(MapNode.NodeType.COMBAT, MapNode.NodeType.SHOP)
+	assert_ne(MapNode.NodeType.COMBAT, MapNode.NodeType.BOSS)
+	assert_ne(MapNode.NodeType.SHOP, MapNode.NodeType.BOSS)
+
+
+func test_default_next_ids_is_empty() -> void:
+	var node := MapNode.new(1, MapNode.NodeType.SHOP, 1)
+	assert_eq(node.next_ids.size(), 0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test`
+Expected: build error — `scripts/map/map_node.gd` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/map/map_node.gd`:
+
+```gdscript
+extends RefCounted
+class_name MapNode
+
+enum NodeType { COMBAT, SHOP, BOSS }
+
+var id: int = -1
+var type: NodeType = NodeType.COMBAT
+var depth: int = 0
+var next_ids: Array[int] = []
+
+
+func _init(p_id: int = -1, p_type: NodeType = NodeType.COMBAT, p_depth: int = 0, p_next_ids: Array[int] = [] as Array[int]) -> void:
+	id = p_id
+	type = p_type
+	depth = p_depth
+	next_ids = p_next_ids.duplicate()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: all unit tests pass, including the three new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/map/map_node.gd tests/unit/test_map_node.gd
+git commit -m "feat(map): add MapNode data class"
+```
+
+---
+
+## Task 2: Create `RunState` with `available_node_ids()`
+
+**Files:**
+- Create: `scripts/map/run_state.gd`
+- Test: `tests/unit/test_run_state.gd`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_run_state.gd`:
+
+```gdscript
+extends GutTest
+
+const MapNode := preload("res://scripts/map/map_node.gd")
+const RunState := preload("res://scripts/map/run_state.gd")
+
+
+func _build_state() -> RunState:
+	# 3 levels: 1 -> 2 (two nodes) -> boss
+	var n1 := MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2, 3] as Array[int])
+	var n2 := MapNode.new(2, MapNode.NodeType.COMBAT, 2, [4] as Array[int])
+	var n3 := MapNode.new(3, MapNode.NodeType.SHOP, 2, [4] as Array[int])
+	var n4 := MapNode.new(4, MapNode.NodeType.BOSS, 3, [] as Array[int])
+	var state := RunState.new()
+	state.nodes = {1: n1, 2: n2, 3: n3, 4: n4}
+	state.current_node_id = -1
+	state.seed = 42
+	return state
+
+
+func test_available_at_start_returns_level_one_nodes() -> void:
+	var state := _build_state()
+	var ids := state.available_node_ids()
+	ids.sort()
+	assert_eq(ids, [1] as Array[int])
+
+
+func test_available_after_entering_node_returns_next_ids() -> void:
+	var state := _build_state()
+	state.current_node_id = 1
+	var ids := state.available_node_ids()
+	ids.sort()
+	assert_eq(ids, [2, 3] as Array[int])
+
+
+func test_available_at_boss_returns_empty() -> void:
+	var state := _build_state()
+	state.current_node_id = 4
+	assert_eq(state.available_node_ids().size(), 0)
+
+
+func test_get_current_node_returns_null_at_start() -> void:
+	var state := _build_state()
+	assert_null(state.get_current_node())
+
+
+func test_get_current_node_returns_node_after_entering() -> void:
+	var state := _build_state()
+	state.current_node_id = 2
+	var node := state.get_current_node()
+	assert_not_null(node)
+	assert_eq(node.id, 2)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test`
+Expected: build error — `scripts/map/run_state.gd` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/map/run_state.gd`:
+
+```gdscript
+extends RefCounted
+class_name RunState
+
+var nodes: Dictionary = {}     # int -> MapNode
+var current_node_id: int = -1  # -1 means no node entered yet
+var seed: int = 0
+
+
+func get_current_node() -> MapNode:
+	if current_node_id == -1:
+		return null
+	return nodes.get(current_node_id, null)
+
+
+func available_node_ids() -> Array[int]:
+	var result: Array[int] = []
+	if current_node_id == -1:
+		for id_key in nodes.keys():
+			var node: MapNode = nodes[id_key]
+			if node.depth == 1:
+				result.append(node.id)
+		return result
+	var current: MapNode = nodes.get(current_node_id, null)
+	if current == null:
+		return result
+	for next_id in current.next_ids:
+		result.append(int(next_id))
+	return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: all `test_run_state.gd` cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/map/run_state.gd tests/unit/test_run_state.gd
+git commit -m "feat(map): add RunState with available_node_ids"
+```
+
+---
+
+## Task 3: Add `map_config.json` and load it via `DataManager`
+
+**Files:**
+- Create: `resources/data/map_config.json`
+- Modify: `scripts/autoload/data_manager.gd`
+- Test: `tests/unit/test_map_generator.gd` (a small loader smoke check; full generator tests come later)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_map_generator.gd` (we'll grow this in Task 4):
+
+```gdscript
+extends GutTest
+
+
+func test_data_manager_exposes_map_config() -> void:
+	var cfg := DataManager.get_map_config()
+	assert_true(cfg is Dictionary)
+	assert_true(cfg.has("depth"))
+	assert_true(cfg.has("min_nodes_per_level"))
+	assert_true(cfg.has("max_nodes_per_level"))
+	assert_true(cfg.has("shop_probability"))
+	assert_true(cfg.has("max_consecutive_shops"))
+	assert_true(cfg.has("boss_blind_multiplier"))
+
+
+func test_map_config_values_are_sane() -> void:
+	var cfg := DataManager.get_map_config()
+	assert_true(int(cfg["depth"]) >= 2)
+	assert_true(int(cfg["min_nodes_per_level"]) >= 1)
+	assert_true(int(cfg["max_nodes_per_level"]) >= int(cfg["min_nodes_per_level"]))
+	var shop_prob := float(cfg["shop_probability"])
+	assert_true(shop_prob >= 0.0 and shop_prob <= 1.0)
+	assert_true(int(cfg["max_consecutive_shops"]) >= 0)
+	assert_true(float(cfg["boss_blind_multiplier"]) >= 1.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test`
+Expected: failure — `DataManager` has no `get_map_config()` method, or returns null.
+
+- [ ] **Step 3: Write the JSON config**
+
+Create `resources/data/map_config.json`:
+
+```json
+{
+  "depth": 6,
+  "min_nodes_per_level": 1,
+  "max_nodes_per_level": 3,
+  "shop_probability": 0.3,
+  "max_consecutive_shops": 2,
+  "boss_blind_multiplier": 1.5
+}
+```
+
+- [ ] **Step 4: Add the loader and validator to `DataManager`**
+
+Edit `scripts/autoload/data_manager.gd`. Add a private field, default constants, validator, getter, and call the loader in `_ready`.
+
+Add at the top of the file (after `var _combo_rules: Array = []`):
+
+```gdscript
+var _map_config: Dictionary = {}
+
+const MAP_CONFIG_DEFAULTS := {
+	"depth": 6,
+	"min_nodes_per_level": 1,
+	"max_nodes_per_level": 3,
+	"shop_probability": 0.3,
+	"max_consecutive_shops": 2,
+	"boss_blind_multiplier": 1.5,
+}
+```
+
+Update `_ready()` to also load the map config:
+
+```gdscript
+func _ready() -> void:
+	_load_faces()
+	_load_shop_catalogue()
+	_load_combo_rules()
+	_load_map_config()
+```
+
+Add new methods at the end of the file:
+
+```gdscript
+func _load_map_config() -> void:
+	var data = _load_json("res://resources/data/map_config.json")
+	if data is Dictionary:
+		_map_config = _validated_map_config(data)
+	else:
+		push_error("map_config.json missing or malformed; using defaults")
+		_map_config = MAP_CONFIG_DEFAULTS.duplicate()
+
+
+func _validated_map_config(raw: Dictionary) -> Dictionary:
+	var cfg := MAP_CONFIG_DEFAULTS.duplicate()
+	for key in MAP_CONFIG_DEFAULTS.keys():
+		if raw.has(key):
+			cfg[key] = raw[key]
+	if int(cfg["depth"]) < 2:
+		push_error("map_config.depth must be >= 2; using default")
+		cfg["depth"] = MAP_CONFIG_DEFAULTS["depth"]
+	if int(cfg["min_nodes_per_level"]) < 1:
+		push_error("map_config.min_nodes_per_level must be >= 1; using default")
+		cfg["min_nodes_per_level"] = MAP_CONFIG_DEFAULTS["min_nodes_per_level"]
+	if int(cfg["max_nodes_per_level"]) < int(cfg["min_nodes_per_level"]):
+		push_error("map_config.max_nodes_per_level must be >= min_nodes_per_level; using default")
+		cfg["max_nodes_per_level"] = MAP_CONFIG_DEFAULTS["max_nodes_per_level"]
+	var shop_prob := float(cfg["shop_probability"])
+	if shop_prob < 0.0 or shop_prob > 1.0:
+		push_error("map_config.shop_probability must be in [0,1]; using default")
+		cfg["shop_probability"] = MAP_CONFIG_DEFAULTS["shop_probability"]
+	if int(cfg["max_consecutive_shops"]) < 0:
+		push_error("map_config.max_consecutive_shops must be >= 0; using default")
+		cfg["max_consecutive_shops"] = MAP_CONFIG_DEFAULTS["max_consecutive_shops"]
+	if float(cfg["boss_blind_multiplier"]) < 1.0:
+		push_error("map_config.boss_blind_multiplier must be >= 1.0; using default")
+		cfg["boss_blind_multiplier"] = MAP_CONFIG_DEFAULTS["boss_blind_multiplier"]
+	return cfg
+
+
+func get_map_config() -> Dictionary:
+	return _map_config.duplicate()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test`
+Expected: `test_data_manager_exposes_map_config` and `test_map_config_values_are_sane` pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resources/data/map_config.json scripts/autoload/data_manager.gd tests/unit/test_map_generator.gd
+git commit -m "feat(map): add map_config.json with DataManager loader and validation"
+```
+
+---
+
+## Task 4: Implement `MapGenerator` — basic shape
+
+**Files:**
+- Create: `scripts/map/map_generator.gd`
+- Test: extend `tests/unit/test_map_generator.gd`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_map_generator.gd`:
+
+```gdscript
+const MapGenerator := preload("res://scripts/map/map_generator.gd")
+const MapNode2 := preload("res://scripts/map/map_node.gd")
+
+
+func _gen() -> Variant:
+	return MapGenerator.generate(12345, DataManager.get_map_config())
+
+
+func test_generate_returns_run_state() -> void:
+	var state = _gen()
+	assert_not_null(state)
+	assert_eq(state.current_node_id, -1)
+	assert_eq(state.seed, 12345)
+
+
+func test_levels_match_depth() -> void:
+	var cfg := DataManager.get_map_config()
+	var state = MapGenerator.generate(1, cfg)
+	var depth: int = int(cfg["depth"])
+	var counts := {}
+	for id_key in state.nodes.keys():
+		var node: MapNode2 = state.nodes[id_key]
+		counts[node.depth] = int(counts.get(node.depth, 0)) + 1
+	for d in range(1, depth + 1):
+		assert_true(counts.has(d), "missing nodes at depth %d" % d)
+		assert_true(int(counts[d]) >= 1, "no nodes at depth %d" % d)
+
+
+func test_boss_is_unique_at_max_depth() -> void:
+	var cfg := DataManager.get_map_config()
+	var state = MapGenerator.generate(2, cfg)
+	var depth: int = int(cfg["depth"])
+	var boss_count := 0
+	for id_key in state.nodes.keys():
+		var node: MapNode2 = state.nodes[id_key]
+		if node.type == MapNode2.NodeType.BOSS:
+			boss_count += 1
+			assert_eq(node.depth, depth)
+			assert_eq(node.next_ids.size(), 0)
+	assert_eq(boss_count, 1)
+
+
+func test_non_boss_nodes_have_outgoing_edges() -> void:
+	var cfg := DataManager.get_map_config()
+	var state = MapGenerator.generate(3, cfg)
+	for id_key in state.nodes.keys():
+		var node: MapNode2 = state.nodes[id_key]
+		if node.type != MapNode2.NodeType.BOSS:
+			assert_true(node.next_ids.size() >= 1, "node %d has no next_ids" % node.id)
+
+
+func test_all_nodes_reachable_from_start() -> void:
+	var cfg := DataManager.get_map_config()
+	var state = MapGenerator.generate(4, cfg)
+	# BFS from any depth-1 node, should cover every node id.
+	var visited := {}
+	var queue: Array[int] = []
+	for id_key in state.nodes.keys():
+		var node: MapNode2 = state.nodes[id_key]
+		if node.depth == 1:
+			queue.append(node.id)
+			visited[node.id] = true
+	while not queue.is_empty():
+		var cur: int = queue.pop_front()
+		var n: MapNode2 = state.nodes[cur]
+		for next_id in n.next_ids:
+			if not visited.has(int(next_id)):
+				visited[int(next_id)] = true
+				queue.append(int(next_id))
+	assert_eq(visited.size(), state.nodes.size())
+
+
+func test_determinism_same_seed_same_map() -> void:
+	var cfg := DataManager.get_map_config()
+	var a = MapGenerator.generate(777, cfg)
+	var b = MapGenerator.generate(777, cfg)
+	assert_eq(a.nodes.size(), b.nodes.size())
+	for id_key in a.nodes.keys():
+		assert_true(b.nodes.has(id_key))
+		var na: MapNode2 = a.nodes[id_key]
+		var nb: MapNode2 = b.nodes[id_key]
+		assert_eq(na.type, nb.type)
+		assert_eq(na.depth, nb.depth)
+		var na_next := na.next_ids.duplicate()
+		var nb_next := nb.next_ids.duplicate()
+		na_next.sort()
+		nb_next.sort()
+		assert_eq(na_next, nb_next)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test`
+Expected: build error or failures — `MapGenerator` does not exist.
+
+- [ ] **Step 3: Write the generator**
+
+Create `scripts/map/map_generator.gd`:
+
+```gdscript
+extends RefCounted
+class_name MapGenerator
+
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+const RunStateRef := preload("res://scripts/map/run_state.gd")
+
+
+static func generate(p_seed: int, config: Dictionary) -> RunStateRef:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = p_seed
+
+	var depth: int = int(config["depth"])
+	var min_nodes: int = int(config["min_nodes_per_level"])
+	var max_nodes: int = int(config["max_nodes_per_level"])
+	var shop_prob: float = float(config["shop_probability"])
+	var max_shops: int = int(config["max_consecutive_shops"])
+
+	var levels: Array = []  # Array[Array[MapNodeRef]]
+	var next_id := 1
+
+	# Levels 1..depth-1: random count and types
+	for d in range(1, depth):
+		var count: int = rng.randi_range(min_nodes, max_nodes)
+		var level: Array = []
+		for _i in range(count):
+			var t := MapNodeRef.NodeType.COMBAT
+			if rng.randf() < shop_prob:
+				t = MapNodeRef.NodeType.SHOP
+			level.append(MapNodeRef.new(next_id, t, d))
+			next_id += 1
+		levels.append(level)
+
+	# Level depth: single boss
+	var boss := MapNodeRef.new(next_id, MapNodeRef.NodeType.BOSS, depth)
+	next_id += 1
+	levels.append([boss])
+
+	_connect_levels(levels, rng)
+	_enforce_max_consecutive_shops(levels, max_shops)
+
+	var state := RunStateRef.new()
+	state.seed = p_seed
+	state.current_node_id = -1
+	for level in levels:
+		for node in level:
+			state.nodes[node.id] = node
+	return state
+
+
+# Connect each node at level L to 1-2 nodes at level L+1, without crossings.
+# Approach: nodes within a level are kept in a fixed order; an edge connects
+# index i at level L to index j at level L+1 only if all chosen edges from
+# the level form a non-crossing fan. We always include "nearest neighbor"
+# edges so every node at L+1 has at least one parent and every node at L
+# has at least one child.
+static func _connect_levels(levels: Array, rng: RandomNumberGenerator) -> void:
+	for li in range(levels.size() - 1):
+		var top: Array = levels[li]
+		var bot: Array = levels[li + 1]
+		# Map each top index to a primary bottom index, monotonically increasing,
+		# covering all bottom indices (so every bottom has a parent).
+		var primary: Array[int] = []
+		for ti in range(top.size()):
+			var bi := int(round(float(ti) * float(bot.size() - 1) / max(1.0, float(top.size() - 1))))
+			if bot.size() == 1:
+				bi = 0
+			primary.append(bi)
+		# Ensure every bottom index has at least one primary parent.
+		var covered := {}
+		for bi in primary:
+			covered[bi] = true
+		for bi in range(bot.size()):
+			if not covered.has(bi):
+				# attach to nearest top index
+				var best_ti := 0
+				var best_dist := 1 << 30
+				for ti in range(top.size()):
+					var d := abs(primary[ti] - bi)
+					if d < best_dist:
+						best_dist = d
+						best_ti = ti
+				primary[best_ti] = bi
+				covered[bi] = true
+		# Now optionally add a second edge per top node (to bi-1 or bi+1) with
+		# probability 0.5, only if it does not cross. "Does not cross" means:
+		# for sorted top index i, its added edge endpoint must be >= primary[i-1]
+		# and <= primary[i+1] (with virtual neighbours as their own primary).
+		for ti in range(top.size()):
+			var node: MapNode = top[ti]
+			node.next_ids = [primary[ti]] as Array[int]
+		for ti in range(top.size()):
+			if rng.randf() < 0.5:
+				var candidates: Array[int] = []
+				var p := primary[ti]
+				if p - 1 >= 0:
+					candidates.append(p - 1)
+				if p + 1 < bot.size():
+					candidates.append(p + 1)
+				# Filter by non-crossing constraint.
+				var allowed: Array[int] = []
+				for c in candidates:
+					var ok := true
+					if ti - 1 >= 0 and c < primary[ti - 1]:
+						ok = false
+					if ti + 1 < top.size() and c > primary[ti + 1]:
+						ok = false
+					if ok:
+						allowed.append(c)
+				if not allowed.is_empty():
+					var pick: int = allowed[rng.randi_range(0, allowed.size() - 1)]
+					var node: MapNode = top[ti]
+					if not node.next_ids.has(pick):
+						node.next_ids.append(pick)
+		# Convert bottom indices stored in next_ids to actual node ids.
+		for ti in range(top.size()):
+			var node: MapNode = top[ti]
+			var resolved: Array[int] = []
+			for bi in node.next_ids:
+				resolved.append((bot[int(bi)] as MapNode).id)
+			resolved.sort()
+			node.next_ids = resolved
+
+
+# For every path from a level-1 node to the boss, no run of SHOP nodes
+# longer than max_shops. We enforce by walking depth-by-depth: if a node's
+# parents all have a chain of `max_shops` shops ending at them, this node
+# must be COMBAT (or BOSS).
+static func _enforce_max_consecutive_shops(levels: Array, max_shops: int) -> void:
+	var streak := {}  # node_id -> int (longest run of SHOPs ending at this node)
+	for li in range(levels.size()):
+		var level: Array = levels[li]
+		for node in level:
+			var parent_max := 0
+			if li == 0:
+				parent_max = 0
+			else:
+				var prev: Array = levels[li - 1]
+				# A node's "incoming" run is the max over parents whose next_ids contain it.
+				var best := -1
+				for p in prev:
+					var p_node: MapNode = p
+					for nid in p_node.next_ids:
+						if int(nid) == node.id:
+							var s := int(streak.get(p_node.id, 0))
+							if s > best:
+								best = s
+							break
+				if best < 0:
+					best = 0  # unreached; should not happen if generator is sound
+				parent_max = best
+			if node.type == MapNode.NodeType.SHOP and parent_max >= max_shops:
+				node.type = MapNode.NodeType.COMBAT
+				streak[node.id] = 0
+			elif node.type == MapNode.NodeType.SHOP:
+				streak[node.id] = parent_max + 1
+			else:
+				streak[node.id] = 0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: all `test_map_generator.gd` cases pass, including reachability and determinism.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/map/map_generator.gd tests/unit/test_map_generator.gd
+git commit -m "feat(map): implement MapGenerator with non-crossing edges and shop streak rule"
+```
+
+---
+
+## Task 5: Add `max_consecutive_shops` test for the generator
+
+**Files:**
+- Modify: `tests/unit/test_map_generator.gd`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_map_generator.gd`:
+
+```gdscript
+func test_no_path_exceeds_max_consecutive_shops() -> void:
+	var cfg := DataManager.get_map_config()
+	cfg["max_consecutive_shops"] = 2
+	cfg["shop_probability"] = 0.95  # force lots of shops
+	var state = MapGenerator.generate(98765, cfg)
+	# DFS all root-to-boss paths, assert no run > 2 shops.
+	var roots: Array[int] = []
+	for id_key in state.nodes.keys():
+		var node: MapNode2 = state.nodes[id_key]
+		if node.depth == 1:
+			roots.append(node.id)
+	for root in roots:
+		_walk(state, root, 0, 2)
+
+
+func _walk(state, node_id: int, current_run_count: int, limit: int) -> void:
+	var n = state.nodes[node_id]
+	var run_after := 0
+	if n.type == MapNode2.NodeType.SHOP:
+		run_after = current_run_count + 1
+	else:
+		run_after = 0
+	assert_true(run_after <= limit, "shop streak %d exceeds %d at node %d" % [run_after, limit, node_id])
+	for next_id in n.next_ids:
+		_walk(state, int(next_id), run_after, limit)
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `make test`
+Expected: pass. If it fails, the generator's streak enforcement has a bug — fix it before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_map_generator.gd
+git commit -m "test(map): assert no path exceeds max_consecutive_shops"
+```
+
+---
+
+## Task 6: Add `Phase.MAP` and `current_run` / `last_run_result` fields to GameManager
+
+**Files:**
+- Modify: `scripts/autoload/game_manager.gd`
+- Test: `tests/integration/test_game_manager.gd` (small additions)
+
+- [ ] **Step 1: Write the failing test**
+
+Open `tests/integration/test_game_manager.gd` and append:
+
+```gdscript
+func test_phase_map_exists() -> void:
+	assert_true(GameManager.Phase.keys().has("MAP"))
+
+
+func test_initial_run_state_is_null() -> void:
+	GameManager.current_run = null
+	GameManager.last_run_result = {}
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.last_run_result, {})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test`
+Expected: failure — `Phase.MAP` does not exist or fields are missing.
+
+- [ ] **Step 3: Modify `GameManager`**
+
+Edit `scripts/autoload/game_manager.gd`.
+
+Replace the `Phase` enum line:
+
+```gdscript
+enum Phase { MAIN_MENU, FLEA_MARKET, DICE_SELECT, COMBAT, MAP }
+```
+
+Add new fields next to `var current_round: int = 1`:
+
+```gdscript
+var current_run: RunState = null
+var last_run_result: Dictionary = {}
+```
+
+Add the `RunState` preload near the top of the file (after `extends Node`):
+
+```gdscript
+const RunState := preload("res://scripts/map/run_state.gd")
+const MapGeneratorRef := preload("res://scripts/map/map_generator.gd")
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+```
+
+In `_change_phase`, add the MAP arm to the existing match:
+
+```gdscript
+		Phase.MAP:
+			get_tree().change_scene_to_file("res://scenes/map/map_screen.tscn")
+```
+
+(The scene file is created in Task 12; it's fine to add this match arm now since `_change_phase` is only invoked for MAP after Task 9.)
+
+In `build_save_data`, ensure `current_run` and `last_run_result` are NOT included. (They aren't, by virtue of not being added — verify by reading the function.)
+
+In `_apply_normalized_save_data`, after the existing assignments add an explicit clear:
+
+```gdscript
+	current_run = null
+	last_run_result = {}
+```
+
+Also handle a `MAP` phase in a save (which we shouldn't write, but defensively). At the top of `build_save_data`, the existing block coerces COMBAT to FLEA_MARKET when not in tutorial; extend it to also coerce MAP to FLEA_MARKET:
+
+```gdscript
+	if (save_phase == Phase.COMBAT or save_phase == Phase.MAP) and not TutorialManager.is_active():
+		save_phase = Phase.FLEA_MARKET
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/autoload/game_manager.gd tests/integration/test_game_manager.gd
+git commit -m "feat(map): add Phase.MAP, current_run, last_run_result on GameManager"
+```
+
+---
+
+## Task 7: Initialize `current_run` in `start_game`; clear in `start_tutorial_replay` and `skip_active_tutorial`
+
+**Files:**
+- Modify: `scripts/autoload/game_manager.gd`
+- Test: `tests/integration/test_game_manager.gd`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/test_game_manager.gd`:
+
+```gdscript
+func test_start_game_creates_run() -> void:
+	GameManager.current_run = null
+	GameManager.start_game(true)  # skip tutorial intro
+	assert_not_null(GameManager.current_run)
+	assert_eq(GameManager.current_run.current_node_id, -1)
+	assert_true(GameManager.current_run.nodes.size() >= 2)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test`
+Expected: failure — `current_run` is null after `start_game`.
+
+- [ ] **Step 3: Modify `start_game`, `start_tutorial_replay`, `skip_active_tutorial`**
+
+In `scripts/autoload/game_manager.gd`, modify `start_game`. Just before `_change_phase(Phase.FLEA_MARKET)` (i.e., right after the existing reset/tutorial branching), add a call:
+
+```gdscript
+	current_run = MapGeneratorRef.generate(randi(), DataManager.get_map_config())
+	last_run_result = {}
+```
+
+Place this at the start of `start_game` after `_reset_run_state()`:
+
+```gdscript
+func start_game(skip_tutorial_intro: bool = false) -> void:
+	delete_save()
+	_reset_run_state()
+	current_run = MapGeneratorRef.generate(randi(), DataManager.get_map_config())
+	last_run_result = {}
+	if skip_tutorial_intro:
+		# ... (rest unchanged)
+```
+
+In `start_tutorial_replay`, immediately after `_reset_run_state()`:
+
+```gdscript
+	current_run = null
+	last_run_result = {}
+```
+
+In `skip_active_tutorial`, after `_reset_run_state()`:
+
+```gdscript
+	current_run = null
+	last_run_result = {}
+```
+
+(Tutorial replay and skip flows are intentionally non-run; you exit them into the legacy single-round loop.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/autoload/game_manager.gd tests/integration/test_game_manager.gd
+git commit -m "feat(map): initialize current_run in start_game; clear in tutorial flows"
+```
+
+---
+
+## Task 8: Split `advance_round` and add `complete_current_node`, `end_run`, `abandon_run`
+
+**Files:**
+- Modify: `scripts/autoload/game_manager.gd`
+- Test: `tests/integration/test_game_manager.gd`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration/test_game_manager.gd`:
+
+```gdscript
+func test_advance_round_outside_run_goes_to_flea_market() -> void:
+	GameManager.current_run = null
+	GameManager.last_run_result = {}
+	GameManager.current_round = 1
+	GameManager.advance_round()
+	assert_eq(GameManager.current_phase, GameManager.Phase.FLEA_MARKET)
+	assert_eq(GameManager.current_round, 2)
+
+
+func test_complete_current_node_in_run_after_first_combat_goes_to_map() -> void:
+	GameManager.start_game(true)
+	# After start_game, current_node_id is -1 and phase is FLEA_MARKET (not under tutorial).
+	# Simulate the first combat ending in victory:
+	GameManager.complete_current_node()
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAP)
+	assert_eq(GameManager.current_round, 2)
+
+
+func test_end_run_victory_returns_to_main_menu_with_result() -> void:
+	GameManager.start_game(true)
+	GameManager.end_run(true)
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAIN_MENU)
+	assert_null(GameManager.current_run)
+	assert_eq(bool(GameManager.last_run_result.get("victory", false)), true)
+
+
+func test_abandon_run_clears_run_without_result() -> void:
+	GameManager.start_game(true)
+	GameManager.abandon_run()
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.last_run_result, {})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test`
+Expected: failures — methods do not exist or behavior is wrong.
+
+- [ ] **Step 3: Refactor `advance_round` and add new methods**
+
+Edit `scripts/autoload/game_manager.gd`. Replace `advance_round` with:
+
+```gdscript
+func _apply_round_advance() -> void:
+	var reward := 10 + 5 * current_round
+	coins += reward
+	coins_changed.emit(coins)
+	current_round += 1
+	target_score = int(floor(BASE_TARGET * pow(1.5, current_round - 1)))
+	selected_dice.clear()
+
+
+func advance_round() -> void:
+	# Legacy single-round flow: bump round and return to flea market.
+	_apply_round_advance()
+	_change_phase(Phase.FLEA_MARKET)
+```
+
+Add new methods at the end of the file:
+
+```gdscript
+func complete_current_node() -> void:
+	# Called after a victorious COMBAT (CombatScreen end_combat dispatch) or
+	# after a SHOP node Continue (FleaMarket "Continue" button) while in a run.
+	if current_run == null:
+		push_warning("complete_current_node called outside of a run")
+		return
+	var node: MapNode = current_run.get_current_node()
+	if node == null:
+		# Onboarding: first combat after start_game (current_node_id == -1).
+		_apply_round_advance()
+		_change_phase(Phase.MAP)
+		return
+	match node.type:
+		MapNodeRef.NodeType.COMBAT:
+			_apply_round_advance()
+			_change_phase(Phase.MAP)
+		MapNodeRef.NodeType.SHOP:
+			_change_phase(Phase.MAP)
+		MapNodeRef.NodeType.BOSS:
+			_apply_round_advance()
+			end_run(true)
+
+
+func enter_map_node(node_id: int) -> void:
+	if current_run == null:
+		push_warning("enter_map_node called outside of a run")
+		return
+	var available := current_run.available_node_ids()
+	if not available.has(node_id):
+		push_warning("enter_map_node ignored: node %d not in available %s" % [node_id, available])
+		return
+	current_run.current_node_id = node_id
+	var node: MapNode = current_run.nodes[node_id]
+	# Boss inherits a higher target via boss_blind_multiplier on top of current target.
+	if node.type == MapNodeRef.NodeType.BOSS:
+		var mult := float(DataManager.get_map_config().get("boss_blind_multiplier", 1.5))
+		target_score = int(floor(float(target_score) * mult))
+	match node.type:
+		MapNodeRef.NodeType.COMBAT, MapNodeRef.NodeType.BOSS:
+			_change_phase(Phase.COMBAT)
+		MapNodeRef.NodeType.SHOP:
+			_change_phase(Phase.FLEA_MARKET)
+
+
+func end_run(victory: bool) -> void:
+	last_run_result = {
+		"victory": victory,
+		"round": current_round,
+		"total_score": total_score,
+		"coins": coins,
+	}
+	current_run = null
+	_change_phase(Phase.MAIN_MENU)
+
+
+func abandon_run() -> void:
+	current_run = null
+	last_run_result = {}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/autoload/game_manager.gd tests/integration/test_game_manager.gd
+git commit -m "feat(map): add complete_current_node, enter_map_node, end_run, abandon_run"
+```
+
+---
+
+## Task 9: Make `end_combat` route-aware (run-driven dispatch)
+
+**Files:**
+- Modify: `scripts/autoload/game_manager.gd`
+- Test: `tests/integration/test_game_manager.gd`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration/test_game_manager.gd`:
+
+```gdscript
+func test_end_combat_in_run_victory_routes_through_complete_current_node() -> void:
+	GameManager.start_game(true)
+	# First combat in run — current_node_id == -1.
+	GameManager.end_combat(GameManager.target_score, true)
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAP)
+
+
+func test_end_combat_in_run_defeat_calls_end_run() -> void:
+	GameManager.start_game(true)
+	GameManager.end_combat(0, false)
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAIN_MENU)
+	assert_null(GameManager.current_run)
+	assert_eq(bool(GameManager.last_run_result.get("victory", false)), false)
+
+
+func test_end_combat_outside_run_uses_legacy_advance_or_main_menu() -> void:
+	GameManager.current_run = null
+	GameManager.last_run_result = {}
+	GameManager.current_round = 1
+	GameManager.end_combat(GameManager.target_score, true)
+	assert_eq(GameManager.current_phase, GameManager.Phase.FLEA_MARKET)
+	assert_eq(GameManager.current_round, 2)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test`
+Expected: failures — `end_combat` still uses the legacy path even in a run.
+
+- [ ] **Step 3: Modify `end_combat`**
+
+Replace `end_combat` in `scripts/autoload/game_manager.gd`:
+
+```gdscript
+func end_combat(final_score: int, target_beaten: bool) -> void:
+	total_score = final_score
+	score_changed.emit(total_score)
+	PokiSDK.gameplay_stop()
+	if current_run != null:
+		if target_beaten:
+			complete_current_node()
+		else:
+			end_run(false)
+		return
+	if target_beaten:
+		advance_round()
+	else:
+		go_to_main_menu()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/autoload/game_manager.gd tests/integration/test_game_manager.gd
+git commit -m "feat(map): make end_combat run-aware"
+```
+
+---
+
+## Task 10: Make FleaMarket "Combat" button route-aware (Continue when in SHOP node)
+
+**Files:**
+- Modify: `scenes/flea_market/flea_market_screen.gd`
+- Test: `tests/integration/test_run_flow.gd` (new)
+
+- [ ] **Step 1: Identify the existing button**
+
+Find the existing combat-button handler in `scenes/flea_market/flea_market_screen.gd`. It calls `GameManager.go_to_combat()`. We won't search-and-replace blindly — locate it first:
+
+Run: `grep -n -E "go_to_combat|on_combat_button|_combat_btn" scenes/flea_market/flea_market_screen.gd`
+
+You should see one or more sites. The key call is `GameManager.go_to_combat()` in the button's `pressed` handler.
+
+- [ ] **Step 2: Write the integration test**
+
+Create `tests/integration/test_run_flow.gd`:
+
+```gdscript
+extends GutTest
+
+const FleaMarketScreen := preload("res://scenes/flea_market/flea_market_screen.gd")
+
+
+func _enter_shop_node() -> void:
+	GameManager.start_game(true)
+	# Simulate first combat victory to land on the map.
+	GameManager.end_combat(GameManager.target_score, true)
+	# Find a SHOP node we can enter.
+	var shop_id := -1
+	for id_key in GameManager.current_run.available_node_ids():
+		var node = GameManager.current_run.nodes[id_key]
+		if node.type == MapNode.NodeType.SHOP:
+			shop_id = int(id_key)
+			break
+	if shop_id == -1:
+		# Force a shop into the available frontier by patching; deterministic seed makes this rare.
+		# Fallback: fabricate a shop node and link it.
+		var shop_node := MapNode.new(9999, MapNode.NodeType.SHOP, 1, [] as Array[int])
+		GameManager.current_run.nodes[9999] = shop_node
+		shop_id = 9999
+	GameManager.enter_map_node(shop_id)
+
+
+func test_flea_market_continue_in_run_returns_to_map() -> void:
+	_enter_shop_node()
+	assert_eq(GameManager.current_phase, GameManager.Phase.FLEA_MARKET)
+	# Simulate "Continue" press by calling the public dispatcher used by the button.
+	GameManager.flea_market_continue()
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAP)
+
+
+func test_flea_market_continue_outside_run_goes_to_combat() -> void:
+	GameManager.current_run = null
+	GameManager.last_run_result = {}
+	GameManager.flea_market_continue()
+	assert_eq(GameManager.current_phase, GameManager.Phase.COMBAT)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `make test`
+Expected: failure — `flea_market_continue` does not exist on `GameManager`.
+
+- [ ] **Step 4: Add the dispatcher on `GameManager`**
+
+In `scripts/autoload/game_manager.gd`, add:
+
+```gdscript
+func flea_market_continue() -> void:
+	# Single entry point used by the FleaMarket "Combat" / "Continue" button.
+	# - Outside a run: legacy → go to combat.
+	# - In a run, current node is a SHOP: complete the node, return to map.
+	# - In a run, no node entered yet (onboarding): go to combat.
+	if current_run == null:
+		_change_phase(Phase.COMBAT)
+		return
+	var node: MapNode = current_run.get_current_node()
+	if node == null:
+		_change_phase(Phase.COMBAT)
+		return
+	if node.type == MapNodeRef.NodeType.SHOP:
+		complete_current_node()
+		return
+	# Defensive: should not be in FleaMarket while current node is COMBAT/BOSS.
+	push_warning("flea_market_continue called with unexpected node type")
+	_change_phase(Phase.MAP)
+```
+
+- [ ] **Step 5: Wire the FleaMarket button to the dispatcher and update its label**
+
+Edit `scenes/flea_market/flea_market_screen.gd`. Replace the call site `GameManager.go_to_combat()` (in the button handler) with `GameManager.flea_market_continue()`.
+
+Then update the button label to reflect run state. Find the place where the combat button is configured (search for the button text — likely "COMBAT" or "Combat"). Add or modify the text-update logic so that on `_ready` or on `phase_changed`:
+
+```gdscript
+func _update_combat_button_label() -> void:
+	var in_run_shop := false
+	if GameManager.current_run != null:
+		var node: MapNode = GameManager.current_run.get_current_node()
+		if node != null and node.type == MapNode.NodeType.SHOP:
+			in_run_shop = true
+	# Replace the actual node reference with the existing button variable in this file.
+	if in_run_shop:
+		_combat_btn.text = "CONTINUE"
+	else:
+		_combat_btn.text = "COMBAT"
+```
+
+Call `_update_combat_button_label()` at the end of `_ready()`. (If the existing file uses different button names, substitute the real node path; the principle is "set text based on run state".)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `make test`
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/autoload/game_manager.gd scenes/flea_market/flea_market_screen.gd tests/integration/test_run_flow.gd
+git commit -m "feat(map): route FleaMarket Continue through GameManager.flea_market_continue"
+```
+
+---
+
+## Task 11: Create `MapNodeButton` scene + script
+
+**Files:**
+- Create: `scenes/map/map_node_button.tscn`
+- Create: `scenes/map/map_node_button.gd`
+- Test: smoke covered by `test_map_screen_smoke.gd` in Task 13
+
+- [ ] **Step 1: Create the script**
+
+Create `scenes/map/map_node_button.gd`:
+
+```gdscript
+extends Button
+class_name MapNodeButton
+
+signal node_clicked(node_id: int)
+
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+
+const COLOR_AVAILABLE := Color(1.0, 0.95, 0.6)
+const COLOR_LOCKED := Color(0.5, 0.5, 0.5)
+const COLOR_COMPLETED := Color(0.4, 0.8, 0.4)
+const COLOR_BOSS := Color(0.9, 0.3, 0.3)
+
+var node_id: int = -1
+var node_type: int = MapNodeRef.NodeType.COMBAT
+var state: String = "locked"  # one of: available, locked, completed
+
+
+func configure(p_id: int, p_type: int, p_state: String) -> void:
+	node_id = p_id
+	node_type = p_type
+	state = p_state
+	_apply_visual()
+	disabled = state != "available"
+
+
+func _ready() -> void:
+	pressed.connect(_on_pressed)
+	custom_minimum_size = Vector2(56, 56)
+	_apply_visual()
+
+
+func _on_pressed() -> void:
+	if state == "available":
+		emit_signal("node_clicked", node_id)
+
+
+func _apply_visual() -> void:
+	var label := _icon_for_type(node_type)
+	text = label
+	var col := COLOR_LOCKED
+	if state == "available":
+		col = COLOR_BOSS if node_type == MapNodeRef.NodeType.BOSS else COLOR_AVAILABLE
+	elif state == "completed":
+		col = COLOR_COMPLETED
+	add_theme_color_override("font_color", col)
+
+
+func _icon_for_type(t: int) -> String:
+	match t:
+		MapNodeRef.NodeType.COMBAT:
+			return "⚔"
+		MapNodeRef.NodeType.SHOP:
+			return "$"
+		MapNodeRef.NodeType.BOSS:
+			return "☠"
+	return "?"
+```
+
+- [ ] **Step 2: Create the scene file**
+
+Create `scenes/map/map_node_button.tscn` as a minimal Button scene with the script attached. Use the editor or hand-write the resource. Hand-written:
+
+```
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/map/map_node_button.gd" id="1"]
+
+[node name="MapNodeButton" type="Button"]
+custom_minimum_size = Vector2(56, 56)
+text = "?"
+script = ExtResource("1")
+```
+
+- [ ] **Step 3: Run static check**
+
+Run: `make static-check`
+Expected: pass — Godot import succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scenes/map/map_node_button.gd scenes/map/map_node_button.tscn
+git commit -m "feat(map): add MapNodeButton scene and script"
+```
+
+---
+
+## Task 12: Create `MapScreen` scene + script (rendering and click dispatch)
+
+**Files:**
+- Create: `scenes/map/map_screen.tscn`
+- Create: `scenes/map/map_screen.gd`
+
+- [ ] **Step 1: Create the script**
+
+Create `scenes/map/map_screen.gd`:
+
+```gdscript
+extends Control
+
+const MapNodeButtonScene := preload("res://scenes/map/map_node_button.tscn")
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+
+const LEVEL_SPACING := 120.0
+const NODE_SPACING := 80.0
+const EDGE_COLOR_DIM := Color(0.5, 0.5, 0.5, 0.6)
+const EDGE_COLOR_AVAILABLE := Color(1.0, 0.95, 0.6, 0.95)
+
+@onready var _coin_label: Label = %CoinLabel
+@onready var _map_container: Control = %MapContainer
+
+var _button_by_id: Dictionary = {}     # int -> MapNodeButton
+var _position_by_id: Dictionary = {}   # int -> Vector2 (center of button)
+
+
+func _ready() -> void:
+	_coin_label.text = str(GameManager.coins)
+	_render_map()
+	_map_container.draw.connect(_draw_edges)
+
+
+func _render_map() -> void:
+	for c in _map_container.get_children():
+		c.queue_free()
+	_button_by_id.clear()
+	_position_by_id.clear()
+
+	var run := GameManager.current_run
+	if run == null:
+		return
+
+	# Group nodes by depth.
+	var levels: Dictionary = {}
+	for id_key in run.nodes.keys():
+		var node: MapNode = run.nodes[id_key]
+		if not levels.has(node.depth):
+			levels[node.depth] = []
+		levels[node.depth].append(node)
+
+	var depths := levels.keys()
+	depths.sort()
+	for d in depths:
+		var level: Array = levels[d]
+		# Sort within level by id for stable layout.
+		level.sort_custom(func(a, b): return a.id < b.id)
+		var count := level.size()
+		for i in range(count):
+			var node: MapNode = level[i]
+			var x := float(d) * LEVEL_SPACING
+			var y := (float(i) - (float(count) - 1.0) * 0.5) * NODE_SPACING
+			var btn: MapNodeButton = MapNodeButtonScene.instantiate()
+			_map_container.add_child(btn)
+			btn.position = Vector2(x, y)
+			btn.configure(node.id, node.type, _state_for(node, run))
+			btn.node_clicked.connect(_on_node_clicked)
+			_button_by_id[node.id] = btn
+			_position_by_id[node.id] = btn.position + btn.custom_minimum_size * 0.5
+
+	_map_container.queue_redraw()
+
+
+func _state_for(node: MapNode, run) -> String:
+	if node.id == run.current_node_id:
+		return "completed"
+	if run.available_node_ids().has(node.id):
+		return "available"
+	return "locked"
+
+
+func _on_node_clicked(node_id: int) -> void:
+	GameManager.enter_map_node(node_id)
+
+
+func _draw_edges() -> void:
+	var run := GameManager.current_run
+	if run == null:
+		return
+	var available := run.available_node_ids()
+	for id_key in run.nodes.keys():
+		var node: MapNode = run.nodes[id_key]
+		var from_pos: Vector2 = _position_by_id.get(node.id, Vector2.ZERO)
+		for next_id in node.next_ids:
+			var to_pos: Vector2 = _position_by_id.get(int(next_id), Vector2.ZERO)
+			var col := EDGE_COLOR_DIM
+			if node.id == run.current_node_id and available.has(int(next_id)):
+				col = EDGE_COLOR_AVAILABLE
+			elif run.current_node_id == -1 and node.depth == 1 and available.has(node.id):
+				col = EDGE_COLOR_AVAILABLE
+			_map_container.draw_line(from_pos, to_pos, col, 2.0)
+```
+
+- [ ] **Step 2: Create the scene file**
+
+Create `scenes/map/map_screen.tscn` (hand-written; the actual layout can be tuned later):
+
+```
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/map/map_screen.gd" id="1"]
+
+[node name="MapScreen" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="Background" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.08, 0.08, 0.12, 1.0)
+
+[node name="Margin" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="VBox" type="VBoxContainer" parent="Margin"]
+
+[node name="TopBar" type="HBoxContainer" parent="Margin/VBox"]
+
+[node name="Title" type="Label" parent="Margin/VBox/TopBar"]
+text = "MAP"
+size_flags_horizontal = 3
+
+[node name="CoinLabel" type="Label" parent="Margin/VBox/TopBar"]
+unique_name_in_owner = true
+text = "0"
+
+[node name="MapContainer" type="Control" parent="Margin/VBox"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(900, 540)
+size_flags_vertical = 3
+```
+
+- [ ] **Step 3: Run static check**
+
+Run: `make static-check`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scenes/map/map_screen.tscn scenes/map/map_screen.gd
+git commit -m "feat(map): add MapScreen scene with node rendering and edge drawing"
+```
+
+---
+
+## Task 13: MapScreen smoke test
+
+**Files:**
+- Create: `tests/smoke/test_map_screen_smoke.gd`
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/smoke/test_map_screen_smoke.gd`:
+
+```gdscript
+extends GutTest
+
+const MapScreenScene := preload("res://scenes/map/map_screen.tscn")
+const MapNode := preload("res://scripts/map/map_node.gd")
+const RunState := preload("res://scripts/map/run_state.gd")
+
+
+func before_each() -> void:
+	# Build a tiny run: one combat node, one boss.
+	var run := RunState.new()
+	var n1 := MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2] as Array[int])
+	var n2 := MapNode.new(2, MapNode.NodeType.BOSS, 2, [] as Array[int])
+	run.nodes = {1: n1, 2: n2}
+	run.current_node_id = -1
+	run.seed = 1
+	GameManager.current_run = run
+
+
+func after_each() -> void:
+	GameManager.current_run = null
+
+
+func test_map_screen_instantiates() -> void:
+	var screen = MapScreenScene.instantiate()
+	add_child_autofree(screen)
+	await get_tree().process_frame
+	assert_not_null(screen)
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `make test`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/smoke/test_map_screen_smoke.gd
+git commit -m "test(map): add MapScreen smoke test"
+```
+
+---
+
+## Task 14: Show ResultsOverlay on MainMenu when `last_run_result` is set
+
+**Files:**
+- Modify: `scenes/main_menu/main_menu.gd`
+- Test: cannot easily integration-test the overlay UI; rely on visual check + GameManager-side test
+
+- [ ] **Step 1: Add the overlay builder and `_show_result_overlay`**
+
+Edit `scenes/main_menu/main_menu.gd`. Append to `_ready()` (after the existing initialization lines, ideally just before the existing settings overlay build):
+
+```gdscript
+	if not GameManager.last_run_result.is_empty():
+		_show_result_overlay()
+```
+
+Add the new method:
+
+```gdscript
+func _show_result_overlay() -> void:
+	var data := GameManager.last_run_result.duplicate()
+	var overlay := ColorRect.new()
+	overlay.color = Color(0, 0, 0, 0.85)
+	overlay.set_anchors_preset(Control.PRESET_FULL_RECT)
+	add_child(overlay)
+
+	var center := CenterContainer.new()
+	center.set_anchors_preset(Control.PRESET_FULL_RECT)
+	overlay.add_child(center)
+
+	var panel := _make_panel(DARK, GOLD, Vector2(420, 0), 32)
+	center.add_child(panel)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 16)
+	panel.add_child(vbox)
+
+	var title := _make_pixel_label("VICTORY" if bool(data.get("victory", false)) else "DEFEATED", 24, GOLD)
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(title)
+
+	var stats := _make_pixel_label(
+		"Round: %d\nScore: %d\nCoins: %d" % [int(data.get("round", 0)), int(data.get("total_score", 0)), int(data.get("coins", 0))],
+		14,
+		Color.WHITE,
+	)
+	stats.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(stats)
+
+	var btn := _make_colored_button("CONTINUE", Vector2(180, 48), GREEN, GREEN.lightened(0.15), 14)
+	btn.pressed.connect(func():
+		GameManager.last_run_result = {}
+		overlay.queue_free()
+	)
+	var btn_center := CenterContainer.new()
+	vbox.add_child(btn_center)
+	btn_center.add_child(btn)
+```
+
+(If `_make_panel`, `_make_pixel_label`, `_make_colored_button` aren't already in `main_menu.gd`, they exist in `pixel_bg.gd` which it extends — verify by grepping.)
+
+- [ ] **Step 2: Run static check**
+
+Run: `make static-check`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scenes/main_menu/main_menu.gd
+git commit -m "feat(map): show run results overlay on MainMenu after end_run"
+```
+
+---
+
+## Task 15: Wire CombatScreen "back to menu" pause action to `abandon_run`
+
+**Files:**
+- Modify: `scenes/combat/combat_screen.gd`
+- Test: `tests/integration/test_run_flow.gd`
+
+- [ ] **Step 1: Identify the menu return site**
+
+Run: `grep -n -E "go_to_main_menu|MenuButton|pause_overlay" scenes/combat/combat_screen.gd`
+
+You'll find one or more sites that take the player from Combat back to the main menu (typically through a pause overlay's "QUIT TO MENU" button). The current call is `GameManager.go_to_main_menu()`.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/integration/test_run_flow.gd`:
+
+```gdscript
+func test_abandon_in_combat_does_not_set_last_run_result() -> void:
+	GameManager.start_game(true)
+	GameManager.abandon_run()
+	GameManager.go_to_main_menu()
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.last_run_result, {})
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `make test`
+Expected: pass already (test only exercises GameManager methods we already wrote).
+
+- [ ] **Step 4: Modify the pause/quit-to-menu handler**
+
+In `scenes/combat/combat_screen.gd`, locate the handler that calls `GameManager.go_to_main_menu()` from a pause/quit button. Replace it with:
+
+```gdscript
+	if GameManager.current_run != null:
+		GameManager.abandon_run()
+	GameManager.go_to_main_menu()
+```
+
+Apply the same change in `scenes/flea_market/flea_market_screen.gd` if it has a similar quit-to-menu path. (Run `grep -n go_to_main_menu scenes/flea_market/flea_market_screen.gd`; if present, wrap the call.)
+
+- [ ] **Step 5: Run tests and static check**
+
+Run: `make test && make static-check`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scenes/combat/combat_screen.gd scenes/flea_market/flea_market_screen.gd tests/integration/test_run_flow.gd
+git commit -m "feat(map): abandon run when player returns to main menu mid-run"
+```
+
+---
+
+## Task 16: Boss multiplier integration test
+
+**Files:**
+- Modify: `tests/integration/test_run_flow.gd`
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/integration/test_run_flow.gd`:
+
+```gdscript
+func test_entering_boss_multiplies_target_score() -> void:
+	GameManager.start_game(true)
+	# Force a deterministic boss-only run for the test.
+	var boss := MapNode.new(1, MapNode.NodeType.BOSS, 1, [] as Array[int])
+	GameManager.current_run.nodes = {1: boss}
+	GameManager.current_run.current_node_id = -1
+	var pre_target := GameManager.target_score
+	var mult := float(DataManager.get_map_config().get("boss_blind_multiplier", 1.5))
+	GameManager.enter_map_node(1)
+	assert_eq(GameManager.current_phase, GameManager.Phase.COMBAT)
+	assert_eq(GameManager.target_score, int(floor(float(pre_target) * mult)))
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `make test`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_run_flow.gd
+git commit -m "test(map): assert boss node applies blind multiplier"
+```
+
+---
+
+## Task 17: Save/load — verify run is not persisted
+
+**Files:**
+- Modify: `tests/integration/test_game_manager.gd`
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/integration/test_game_manager.gd`:
+
+```gdscript
+func test_save_does_not_serialize_run() -> void:
+	GameManager.start_game(true)
+	var data := GameManager.build_save_data()
+	assert_false(data.has("current_run"))
+	assert_false(data.has("last_run_result"))
+
+
+func test_loading_save_clears_run_state() -> void:
+	GameManager.start_game(true)
+	var data := GameManager.build_save_data()
+	GameManager.last_run_result = {"victory": true}
+	GameManager.apply_save_data(data)
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.last_run_result, {})
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `make test`
+Expected: pass — `build_save_data` was never modified to include the new fields, and Task 6 already added the explicit clear in `_apply_normalized_save_data`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_game_manager.gd
+git commit -m "test(map): verify run state is not persisted in save"
+```
+
+---
+
+## Task 18: Final validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full validation loop**
+
+Run: `make validate`
+Expected: pass — tests, lint, format-check, typecheck, security all green.
+
+- [ ] **Step 2: Manual smoke (editor)**
+
+Open the project in Godot 4.6 and play it. Verify:
+
+1. New Game from MainMenu → FleaMarket appears (button says "COMBAT").
+2. Press Combat → fight a round; on victory you arrive at the Map screen.
+3. Map shows ~6 columns of nodes; only level-1 nodes are clickable.
+4. Click an available Combat node → Combat screen with a higher target than before; win → back to Map.
+5. Click an available Shop node → FleaMarket appears, button now says "CONTINUE"; press → back to Map.
+6. Reach the boss, win → MainMenu shows VICTORY overlay with stats.
+7. Start another run, lose a combat → MainMenu shows DEFEATED overlay.
+8. Start a run, hit the pause/quit-to-menu button mid-combat → MainMenu, no overlay.
+
+If any step fails, fix and re-run `make validate` before committing.
+
+- [ ] **Step 3: Commit any fixes**
+
+If you made code changes during manual smoke, commit them per the existing pattern.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All sections of the design spec (architecture, run flow, generation, blinds, UI, tests, edge cases) are mapped to tasks. The addendum's reconciliation points (`current_round` reuse, `_apply_round_advance` split, no save persistence, abandon vs end_run) are covered in Tasks 6–9, 15, 17.
+- **Placeholders:** No TBDs. Every step has either runnable code or an exact command.
+- **Type consistency:** `MapNode.NodeType.{COMBAT, SHOP, BOSS}` is used consistently. `RunState.available_node_ids() -> Array[int]` matches all callers. `complete_current_node`, `enter_map_node`, `end_run`, `abandon_run`, `flea_market_continue` all defined in Task 8/10 and used identically afterward.
+- **Risk note:** Task 10 step 1 grep is the only "discover then patch" step. If the FleaMarket combat-button handler is more entangled than expected (e.g. multiple buttons share logic), you may need a small adapter — keep the call replacement minimal: `GameManager.go_to_combat()` → `GameManager.flea_market_continue()` and a label refresh on `phase_changed`.

--- a/knowledge/ARCHITECTURE.md
+++ b/knowledge/ARCHITECTURE.md
@@ -1,184 +1,272 @@
 # Architecture
 
-## Three Screens
+Probabimals is a Godot 4.6 GDScript dice strategy game. Runtime state is routed through autoload managers, player-facing surfaces are Godot scenes, and gameplay tuning is kept in JSON data under `resources/data/`.
 
-- **Screen 1 — MainMenu**: Start and Exit buttons.
-- **Screen 2 — FleaMarket**: Simplified shop (fixed catalogue of items) + dice bag management on one screen. Player buys dice, faces, and modifiers. Coin counter. "Combat" button to proceed.
-- **Screen 3 — Combat**: The player's dice bag is shown. Player rolls 5 dice, keeps some, rerolls the rest (up to 2 rerolls). Score accumulates across hands. Combat ends when the player exhausts all hands or beats the target score. Results overlay appears with final score.
+## Runtime Flow
 
-**Flow:** MainMenu → FleaMarket → Combat → MainMenu (FULL44 adds: Combat → FleaMarket for next round).
+The normal run flow is:
 
----
+`MainMenu -> Map -> DiceSelect -> Combat -> Map`
+
+Map nodes decide which preparation surface comes next:
+
+- **Combat/Boss nodes** route to `DiceSelect`, then `Combat`.
+- **Shop nodes** route to `FleaMarket`, then back to `Map`.
+- **Boss victory** ends the run with a victory result.
+- **Combat defeat** ends the run with a defeat result.
+- **Menu/quit from active run phases** abandons the run and deletes the active save without a victory/defeat result.
+
+First-run tutorial bootstraps the same run state but temporarily follows:
+
+`Intro Combat -> FleaMarket tutorial -> DiceSelect tutorial -> Tutorial Combat -> Map`
+
+The intro combat is special-cased while the tutorial intro step is active. After the final tutorial combat completes, the tutorial is inactive and the still-unselected run (`current_node_id == -1`) routes to `Map`.
+
+## Screens
+
+- **MainMenu**: start, continue, settings/tutorial replay, survey, exit, and victory/defeat run result overlay.
+- **Map**: generated 10-depth route map with start, combat, shop, and boss nodes. Opens near the next relevant node and persists run state.
+- **FleaMarket**: shop plus dice bag management. Used both outside a run and for shop map nodes. Shop-node offerings, sold flags, and reroll count persist on the current `RunState`.
+- **DiceSelect**: choose dice from the bag before combat. Active-run menu exits abandon the run.
+- **Combat**: roll/hold/reroll/score loop with probability panel, pause/result overlays, tutorial overlay support, and run result resolution.
 
 ## Directory Structure
 
 ```
 project.godot
 
+resources/
+  data/
+    combos.json                  # combo definitions and scoring rules
+    dice_shop.json               # shop catalogue
+    faces.json                   # face definitions
+    map_config.json              # map depth, node counts, shop chance, boss multiplier
+
 scenes/
   main_menu/
-    main_menu.tscn               # Start / Exit screen
+    main_menu.tscn
     main_menu.gd
+  map/
+    map_screen.tscn              # map UI, edge drawing, scrolling
+    map_screen.gd
+    map_node_button.tscn         # icon + caption button for map nodes
+    map_node_button.gd
   flea_market/
-    flea_market_screen.tscn      # shop + dice bag management combined
+    flea_market_screen.tscn
     flea_market_screen.gd
-    shop_item.tscn               # single item card in shop shelf
-    shop_item.gd
-    die_card.tscn                # die card in bag display
-    die_card.gd
-    face_slot.tscn               # face slot on a die (for swapping)
-    face_slot.gd
+  dice_select/
+    dice_select_screen.tscn
+    dice_select_screen.gd
   combat/
-    combat_screen.tscn           # combat phase UI
+    combat_screen.tscn
     combat_screen.gd
-    dice_tray_visual.tscn        # the rolling area showing 5 dice
-    dice_tray_visual.gd
-    die_visual.tscn              # single die visual (shows face result)
-    die_visual.gd
 
 scripts/
   autoload/
-    game_manager.gd              # game state, phase transitions, player wallet
-    data_manager.gd              # loads & serves JSON data
+    game_manager.gd              # phase routing, run state, save/load, wallet, combat results
+    data_manager.gd              # JSON loading and validated data access
+    tutorial_manager.gd          # tutorial mode, checkpoints, scripted tutorial requirements
+    audio_manager.gd             # SFX/music and volume persistence
+  map/
+    map_generator.gd             # data-driven route generation
+    map_node.gd                  # node id/type/depth/edges
+    run_state.gd                 # current run graph, progress, shop states
   dice/
-    die.gd                       # single die (RefCounted): holds 6 faces, color
-    dice_bag.gd                  # player's bag of dice, draw logic
+    die.gd
+    dice_bag.gd
+    dice_face.gd
   scoring/
-    scoring_engine.gd            # combo detection + point calculation
-    combo_detector.gd            # identifies combos in a set of rolled values
+    combo_detector.gd
+    combo_odds_helper.gd
+    modifier.gd
+    scoring_engine.gd
   combat/
-    combat_manager.gd            # orchestrates roll-reroll-score loop
-
-assets/
-  art/
-    dice/                        # die sprites, face icons
-    modifiers/                   # modifier card artwork
-    ui/                          # buttons, panels, backgrounds
-  audio/
-    sfx/
-    music/
-  fonts/
-
-resources/
-  data/
-    faces.json                   # face definitions (id, value, rarity)
-    dice_shop.json               # shop catalogue (dice, faces, modifiers with costs)
-    combos.json                  # combo definitions and scoring rules
-  themes/
-    default_theme.tres
+    combat_manager.gd
+    combat_dice.gd
+    combat_probability_panel.gd
+  shop/
+    shop_generator.gd
+  ui/
+    pixel_bg.gd
+    item_card.gd
+    shop_item_card.gd
+    dice_face_panel.gd
+    tutorial_overlay.gd
+    combo_reveal_fx.gd
 ```
 
----
-
-## Autoloads (Singletons)
+## Autoloads
 
 ### GameManager (`scripts/autoload/game_manager.gd`)
 
-- `current_phase: Phase` — MAIN_MENU, FLEA_MARKET, COMBAT
-- `coins: int` — player's currency
-- `dice_bag: DiceBag` — player's collection of dice
-- `modifiers: Array[Modifier]` — active modifiers
-- `total_score: int`
-- Signals: `phase_changed`, `coins_changed`, `score_changed`
-- Methods: `start_game()`, `go_to_combat()`, `end_combat()`, `buy_item()`, `swap_face()`
+`GameManager` is the central phase and run-state coordinator.
+
+Key state:
+
+- `current_phase: Phase` — `MAIN_MENU`, `FLEA_MARKET`, `DICE_SELECT`, `COMBAT`, `MAP`.
+- `current_run: RunState` — active generated map run, or `null` outside active runs.
+- `last_run_result: Dictionary` — transient victory/defeat data rendered by MainMenu.
+- `coins`, `dice_bag`, `modifiers`, `selected_dice`, `total_score`, `target_score`, `current_round`, `hands_per_round`, `rerolls_per_hand`.
+- `save_path` and save format metadata.
+
+Primary methods:
+
+- `start_game(skip_tutorial_intro := false)` resets state, creates a generated run, and routes either to intro combat or map.
+- `start_tutorial_replay()` runs tutorial without keeping the active map run.
+- `skip_active_tutorial()` completes tutorial and creates/routes to a normal map run.
+- `enter_map_node(node_id)` validates availability, marks the current map node, applies boss target scaling when needed, then routes to dice select or flea market.
+- `complete_current_node()` applies combat/shop/boss completion effects and routes to map or run end.
+- `end_combat(final_score, target_beaten)` applies combat result state and immediately changes phase.
+- `resolve_combat_result_for_overlay(final_score, target_beaten)` applies active-run combat result state and writes/deletes the save while the Combat result overlay remains visible.
+- `finish_resolved_combat_result()` changes scene after the player presses the already-resolved result overlay button.
+- `flea_market_continue()` completes shop nodes or falls back to dice select outside runs.
+- `end_run(victory)` sets `last_run_result`, clears `current_run`, deletes the save, and routes to MainMenu.
+- `abandon_run()` clears the active run without result feedback and deletes the save.
+
+Signals:
+
+- `phase_changed(new_phase)`
+- `coins_changed(new_amount)`
+- `score_changed(new_score)`
 
 ### DataManager (`scripts/autoload/data_manager.gd`)
 
-- Loads JSON files at `_ready()`
-- `get_all_faces()`, `get_face(id)`, `get_shop_catalogue()`, `get_combo_rules()`
-- Pure data accessor — no game logic
+`DataManager` loads and validates JSON gameplay data at boot.
 
----
+Accessors include:
 
-## Item Taxonomy
+- `get_all_faces()`, `get_face(id)`
+- `get_shop_catalogue()`
+- `get_combo_rules()`
+- `get_map_config()`
 
-### Dice (add to bag)
+`get_map_config()` validates map settings and falls back to safe defaults when data is invalid.
 
-- **Die** — a six-sided die with customizable faces. Base dice are colorless with default faces 1–6. Colored dice are rarer and enable flush combos.
+### TutorialManager (`scripts/autoload/tutorial_manager.gd`)
 
-### Faces (swap onto a die)
+`TutorialManager` owns first-run and replay tutorial state:
 
-- **Face** — replaces one side of a die. Changes the number distribution (e.g. a face with value 6 replaces a face with value 1, making 6 more likely).
+- tutorial mode/completion/checkpoint scene
+- current step id
+- scripted roll values
+- required shop purchases, dice selections, and combat holds
+- save/load serialization for tutorial checkpoint persistence
 
-### Modifiers (global scoring effects)
+Scene scripts call `TutorialManager.report_action(...)` and `enter_scene(...)` to advance tutorial steps.
 
-- **Score Modifier** — multiplies or transforms scoring (e.g. "Full Houses score double").
-- **Combo Modifier** — changes combo rules (e.g. "pairs count as triples").
-- **Reroll Modifier** — grants extra rerolls or other roll manipulation.
+## Map And Run Systems
 
----
+### MapNode (`scripts/map/map_node.gd`)
 
-## Core Systems
+`MapNode` is a lightweight value object:
+
+- `id`
+- `type` — `COMBAT`, `SHOP`, or `BOSS`
+- `depth`
+- `next_ids`
+
+### RunState (`scripts/map/run_state.gd`)
+
+`RunState` stores one generated map run:
+
+- `nodes: Dictionary`
+- `seed: int`
+- `current_node_id: int` (`-1` before the first selected node)
+- `visited_node_ids`
+- `completed_node_ids`
+- `shop_states`
+
+It exposes current-node lookup, enter/complete helpers, availability calculation, and per-shop state get/set helpers.
+
+### MapGenerator (`scripts/map/map_generator.gd`)
+
+`MapGenerator.generate(seed, config)` builds a run graph from `resources/data/map_config.json`.
+
+The default map is 10 depths. Depth 1 contains initial choices, the final depth contains a boss, and middle depths mix combat/shop nodes while preserving valid forward edges.
+
+## Save And Load
+
+`GameManager.build_save_data()` writes format-versioned JSON with player state, tutorial state, and `current_run` when present.
+
+Save behavior:
+
+- Non-tutorial `COMBAT` saves normalize to `DICE_SELECT` for active runs, so a mid-combat reload restarts before combat rather than inside a volatile roll state.
+- `MAP` without an active run normalizes to `FLEA_MARKET` for legacy compatibility.
+- Active run state includes serialized map nodes, current node, visited/completed nodes, and shop states.
+- Run victory/defeat and abandon delete the active save so MainMenu cannot continue stale pre-end state.
+- Active-run Combat result overlays resolve state immediately: victory writes the next `MAP`/run-end state before the overlay button is pressed; defeat deletes the save and records defeat result data before the overlay button is pressed.
+
+`GameManager.apply_save_data()` migrates old saves to the current format, restores player/run/tutorial state, and returns the phase to load.
+
+## Core Gameplay Systems
 
 ### Dice System
 
-- `Die` (RefCounted) — holds an array of 6 face values and an optional color. `roll()` returns a random face value (uniform distribution across the 6 faces).
-- `DiceBag` (RefCounted) — holds the player's collection of dice. `draw(n)` returns n dice for rolling. Tracks which dice are in the bag.
+- `Die` holds six `DiceFace` instances plus metadata such as color/name/rarity.
+- `DiceBag` stores owned dice and supplies draw/get/remove helpers.
+- Faces can be swapped in the flea market to alter probability distributions.
 
-### Scoring Engine
+### Scoring
 
-- `ComboDetector` (RefCounted) — `detect_combos(results: Array[int])` analyzes 5 rolled values and returns the best combo (Pair, Two Pair, Three of a Kind, Full House, Small Straight, Large Straight, Four of a Kind, Yahtzee). With colored dice, also detects Flush.
-- `ScoringEngine` (RefCounted) — `calculate_hand_score(combo, values, modifiers)` returns base points, multiplier, and total. Applies active modifiers.
-
-### Combat Manager
-
-- `CombatManager` (Node) — created by CombatScreen. Tracks running score, hands remaining, rerolls remaining.
-- `roll_dice()` — rolls all unheld dice, emits `dice_rolled` signal.
-- `hold_die(index)` / `unhold_die(index)` — toggles hold state on a die.
-- `score_hand()` — evaluates the current roll, scores it, emits `hand_scored` signal.
-- `end_combat()` — called by player or auto when all hands exhausted. Emits `combat_ended`.
-
----
-
-## Data Formats
-
-### faces.json
-
-Each face: `id`, `value` (the number shown), `rarity`, `cost`.
-
-### dice_shop.json
-
-Each shop item: `id`, `name`, `description`, `category` (die/face/modifier), `cost`, `params`.
-
-### combos.json
-
-Combo definitions: `name`, `pattern` (e.g. "three_of_a_kind"), `base_score`, `multiplier`.
-
----
-
-## Scene Trees (Summary)
-
-### MainMenu
-Control root → Background (ColorRect) → CenterContainer → VBoxContainer with Title, StartButton, ExitButton.
-
-### FleaMarket
-Control root → Background → MarginContainer → MainVBox:
-- TopBar: title, CoinLabel, CombatButton
-- ContentSplit (HSplitContainer): ShopPanel (GridContainer of ShopItems) | BagPanel (VBoxContainer showing dice in bag with face details)
-- InfoPanel: selected item details, buy/swap buttons
+- `ComboDetector` identifies the best Yahtzee-style combo for rolled values.
+- `ScoringEngine` calculates total score from combo rules, dice faces, dice colors, and active modifiers.
+- `ComboOddsHelper` powers combat probability display for current held/unheld dice.
 
 ### Combat
-Control root → Background → MarginContainer → VBoxContainer:
-- TopBar: MenuButton, "COMBAT" title, CombosButton (opens combo info overlay)
-- HandInfoLabel: "Hand X/Y" subtitle
-- ScorePanel: combo name, score value, breakdown
-- DiceTray: HBoxContainer of 5 DieVisuals (clickable to hold/unhold)
-- DescPanel: hover tooltip for dice
-- ScoreBar: progress bar toward target score
-- ActionBar: RollButton, EndTurnButton
-- ResultOverlay (ColorRect, initially hidden): final score, next round / menu buttons
-- PauseOverlay (ColorRect, initially hidden): resume / quit buttons
-- ComboOverlay (ColorRect, initially hidden): 9 combo rows with pattern colors and effective multipliers, current combo highlighted
 
----
+`CombatManager` owns the roll/reroll/score loop and emits signals consumed by `CombatScreen`:
+
+- `roll_dice()`
+- `toggle_hold(index)`
+- `score_hand(modifiers)`
+- `combat_ended(final_score, target_beaten)`
+
+`CombatScreen` owns presentation, overlays, animation, tutorial gating, and result-overlay navigation. It delegates durable state changes to `GameManager`.
+
+### Shop
+
+`ShopGenerator` builds randomized offerings from `dice_shop.json`.
+
+`FleaMarketScreen` handles purchases, face swaps, rerolls, tutorial market steps, and persistence of map shop-node state through `RunState.shop_states`.
+
+## Scene Trees
+
+### MainMenu
+
+Control root with pixel background, title, Start/Continue/Settings/Survey/Exit buttons, settings overlay, and run result overlay.
+
+### Map
+
+Pixel background with top bar (`MENU`, title, coins), framed scroll container, generated map node buttons, drawn start/path edges, and automatic scroll-to-relevant-node behavior.
+
+### FleaMarket
+
+Pixel background with top bar, coin display, shop offerings, inventory/dice face management, ready/continue routing, and tutorial overlay integration.
+
+### DiceSelect
+
+Pixel background with dice selection groups, selected dice list, ready/menu controls, and tutorial constraints for required dice.
+
+### Combat
+
+Pixel background with top bar, score/probability surfaces, dice tray, action buttons, hover description panel, combo reveal effects, tutorial overlay, pause overlay, combo overlay, and result overlay.
+
+## Testing Strategy
+
+- `tests/unit`: pure data/model/logic coverage such as map generation, run state, dice, scoring, shop generation, and tutorial manager.
+- `tests/integration`: manager and cross-scene run flows, save/load, abandon/end-run behavior, shop persistence, combat result overlay persistence.
+- `tests/smoke`: scene instantiation and structural UI checks for main menu, map, combat, tutorial E2E, and layout constraints.
+
+Use `make test` for the full GUT suite, `make static-check` for Godot import/syntax sanity, and `make lint`/`make format-check` for style.
 
 ## BASIC4 vs FULL44 Scope
 
 | System | BASIC4 | FULL44 adds |
 |--------|--------|-------------|
-| Dice | 5 colorless dice, default faces | Colored dice, flush combos, larger bag |
-| Flea Market | Fixed catalogue, flat coin budget | Randomized stock, scaling prices, rarity tiers |
-| Items | ~10–12 items: dice, faces, modifiers | Large pool, synergies, conditional modifiers |
-| Combat | Roll + reroll, Yahtzee combos, single target score | Escalating blinds, rich modifier interactions |
-| Progression | Single round | 5–7 rounds, persistent inventory, difficulty scaling |
-| Polish | Placeholder art, no sound | Animations, SFX, music, tutorial |
+| Dice | 5 colorless dice, default faces | Larger bag, rarity-driven dice, richer face/modifier pool |
+| Flea Market | Fixed/simple catalogue | Randomized stock, rerolls, persistent shop-node state |
+| Items | Dice, faces, modifiers | Synergies, rarity tiers, conditional modifiers |
+| Combat | Roll + reroll, Yahtzee combos, single target | Escalating targets, probability panel, richer feedback |
+| Progression | Single round | 10-depth map run with combat/shop/boss nodes |
+| Save/Results | Basic continue | Versioned run saves, victory/defeat overlays, stale-save protection |
+| Polish | Placeholder UI | Animations, SFX/music, tutorial, map icons/captions |

--- a/knowledge/FULL44.md
+++ b/knowledge/FULL44.md
@@ -27,7 +27,7 @@ The complete demo experience showcasing all core systems working together across
 
 ### Progression
 
-- **Multi-round structure** — at least 5–7 rounds with escalating blinds.
+- **Multi-round structure** — 10 map levels with escalating blinds.
 - **Flea market evolution** — later rounds offer rarer faces and more powerful modifiers.
 - **Win/loss conditions** — the player wins the demo by surviving all rounds; losing a round has consequences (e.g. losing dice, reduced budget).
 

--- a/resources/data/map_config.json
+++ b/resources/data/map_config.json
@@ -1,0 +1,8 @@
+{
+  "depth": 10,
+  "min_nodes_per_level": 1,
+  "max_nodes_per_level": 3,
+  "shop_probability": 0.3,
+  "max_consecutive_shops": 2,
+  "boss_blind_multiplier": 1.5
+}

--- a/scenes/combat/combat_screen.gd
+++ b/scenes/combat/combat_screen.gd
@@ -7,6 +7,7 @@ const ScoreFormat = preload("res://scripts/ui/score_format.gd")
 const TutorialOverlay = preload("res://scripts/ui/tutorial_overlay.gd")
 const SemanticMarkup = preload("res://scripts/ui/semantic_markup.gd")
 const SemanticColors = preload("res://scripts/ui/semantic_colors.gd")
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
 const COMBAT_CONTENT_SEPARATION := 32
 const COMBAT_TOP_BAR_SEPARATION := 16
 const COMBAT_MENU_SHADOW_OFFSET := Vector2(4, 4)
@@ -645,6 +646,15 @@ func _on_resume_pressed() -> void:
 func _on_pause_quit_pressed() -> void:
 	_pause_overlay.visible = false
 	get_tree().paused = false
+	if GameManager.current_run != null:
+		var tween := create_tween()
+		tween.tween_property(self, "modulate:a", 0.0, 0.3)
+		tween.tween_callback(
+			func():
+				GameManager.abandon_run()
+				GameManager.go_to_main_menu()
+		)
+		return
 	_result_final_score = combat_mgr.running_score
 	_result_target_beaten = false
 	_go_to_main_menu()
@@ -1372,6 +1382,16 @@ func _on_combat_ended(final_score: int, target_beaten: bool) -> void:
 	_result_target_beaten = target_beaten
 	_show_result_overlay(final_score, target_beaten)
 	_refresh_tutorial_ui()
+	if _should_resolve_combat_result_on_overlay(target_beaten):
+		GameManager.resolve_combat_result_for_overlay(final_score, target_beaten)
+
+
+func _should_resolve_combat_result_on_overlay(target_beaten: bool) -> bool:
+	if GameManager.current_run == null:
+		return false
+	if TutorialManager.is_active():
+		return false
+	return target_beaten or GameManager.current_run != null
 
 
 func _show_result_overlay(final_score: int, target_beaten: bool) -> void:
@@ -1383,7 +1403,9 @@ func _show_result_overlay(final_score: int, target_beaten: bool) -> void:
 	_result_score_label.text = str(final_score) + " PTS"
 
 	if target_beaten:
-		if GameManager.current_round == 0:
+		if _is_current_map_boss_node():
+			_result_message.text = "BOSS DEFEATED!"
+		elif GameManager.current_round == 0:
 			_result_message.text = "ROUND CLEARED!"
 		else:
 			_result_message.text = "ROUND %d CLEARED!" % GameManager.current_round
@@ -1392,13 +1414,21 @@ func _show_result_overlay(final_score: int, target_beaten: bool) -> void:
 			_result_sub_label.text = "Great start! Now let's head to the Flea Market and upgrade your dice."
 		elif TutorialManager.is_active():
 			_result_sub_label.text = "Great job! You improved your dice, held a strong pair, and turned it into a big combo. You've got the basics down!"
+		elif _is_run_start_map_transition():
+			_result_sub_label.text = "Choose your first route on the map."
+		elif _is_current_map_boss_node():
+			_result_sub_label.text = "Final target: %d" % GameManager.target_score
 		else:
 			_result_sub_label.text = "Target: %d" % GameManager.target_score
 		var reward := GameManager.get_round_reward()
 		_result_coins_label.text = (
 			"[center]+%d%s[/center]" % [reward, SemanticMarkup.coin_icon(COMBAT_RESULT_COINS_FONT_SIZE + 4)]
 		)
-		_result_coins_label.visible = true
+		_result_coins_label.visible = not _is_run_start_map_transition()
+		if _is_run_start_map_transition():
+			_result_next_btn.text = "VIEW MAP"
+		else:
+			_result_next_btn.text = "FINISH RUN" if _is_current_map_boss_node() else "NEXT ROUND"
 		_result_next_btn.visible = true
 		_result_retry_btn.visible = false
 		_result_survey_btn.visible = false
@@ -1410,6 +1440,7 @@ func _show_result_overlay(final_score: int, target_beaten: bool) -> void:
 			_result_sub_label.text = "No worries -- give it another shot! The tutorial is here to help you practice."
 			_result_coins_label.visible = false
 			_result_next_btn.visible = false
+			_result_next_btn.text = "NEXT ROUND"
 			_result_retry_btn.visible = true
 			_result_survey_btn.visible = false
 			_result_menu_btn.visible = true
@@ -1419,6 +1450,7 @@ func _show_result_overlay(final_score: int, target_beaten: bool) -> void:
 			_result_sub_label.text = "Reached Round %d" % GameManager.current_round
 			_result_coins_label.visible = false
 			_result_next_btn.visible = false
+			_result_next_btn.text = "NEXT ROUND"
 			_result_retry_btn.visible = false
 			_result_survey_btn.visible = true
 			_result_menu_btn.visible = true
@@ -1427,6 +1459,21 @@ func _show_result_overlay(final_score: int, target_beaten: bool) -> void:
 	tween.set_ease(Tween.EASE_OUT)
 	tween.set_trans(Tween.TRANS_CUBIC)
 	tween.tween_property(_result_overlay, "modulate:a", 1.0, 0.5)
+
+
+func _is_current_map_boss_node() -> bool:
+	if GameManager.current_run == null:
+		return false
+	var node = GameManager.current_run.get_current_node()
+	return node != null and node.type == MapNodeRef.NodeType.BOSS
+
+
+func _is_run_start_map_transition() -> bool:
+	return (
+		GameManager.current_run != null
+		and GameManager.current_run.current_node_id == -1
+		and not TutorialManager.is_active()
+	)
 
 
 func _get_pattern_colors(combo_type: String) -> Array:
@@ -1466,7 +1513,10 @@ func _on_next_round_pressed() -> void:
 		TutorialManager.report_action("combat_next_round")
 	var tween := create_tween()
 	tween.tween_property(self, "modulate:a", 0.0, 0.3)
-	tween.tween_callback(func(): GameManager.end_combat(_result_final_score, true))
+	if GameManager.has_resolved_combat_result():
+		tween.tween_callback(GameManager.finish_resolved_combat_result)
+	else:
+		tween.tween_callback(func(): GameManager.end_combat(_result_final_score, true))
 
 
 func _on_playtest_survey_pressed() -> void:
@@ -1476,7 +1526,10 @@ func _on_playtest_survey_pressed() -> void:
 func _go_to_main_menu() -> void:
 	var tween := create_tween()
 	tween.tween_property(self, "modulate:a", 0.0, 0.3)
-	tween.tween_callback(func(): GameManager.end_combat(_result_final_score, false))
+	if GameManager.has_resolved_combat_result():
+		tween.tween_callback(GameManager.finish_resolved_combat_result)
+	else:
+		tween.tween_callback(func(): GameManager.end_combat(_result_final_score, false))
 
 
 func _build_tutorial_overlay() -> void:

--- a/scenes/dice_select/dice_select_screen.gd
+++ b/scenes/dice_select/dice_select_screen.gd
@@ -299,6 +299,12 @@ func _on_confirm_pressed() -> void:
 	GameManager.go_to_combat()
 
 
+func _go_to_main_menu() -> void:
+	if GameManager.current_run != null:
+		GameManager.abandon_run()
+	GameManager.go_to_main_menu()
+
+
 func _group_is_required(group: Dictionary) -> bool:
 	if not TutorialManager.is_active():
 		return false

--- a/scenes/flea_market/flea_market_screen.gd
+++ b/scenes/flea_market/flea_market_screen.gd
@@ -6,6 +6,7 @@ const ShopGeneratorScript = preload("res://scripts/shop/shop_generator.gd")
 const ScoreFormat = preload("res://scripts/ui/score_format.gd")
 const TutorialOverlay = preload("res://scripts/ui/tutorial_overlay.gd")
 const SemanticMarkup = preload("res://scripts/ui/semantic_markup.gd")
+const MapNodeRef = preload("res://scripts/map/map_node.gd")
 const REROLL_COST := 10
 const SHOP_SLOTS := ShopGeneratorScript.DEFAULT_SHOP_SLOTS
 const FLEA_MARKET_CONTENT_SEPARATION := 48
@@ -68,11 +69,13 @@ var _pending_shop_index: int = -1
 var _selected_die_index: int = -1
 var _tutorial_overlay: Control
 var _shop_generator = ShopGeneratorScript.new()
+var _reroll_count: int = 0
 
 
 func _ready() -> void:
 	super._ready()
-	_shop_generator.randomize_seed()
+	if not _is_active_run_shop_node():
+		_shop_generator.randomize_seed()
 	_build_ui()
 	_generate_offerings()
 	_update_coins()
@@ -240,6 +243,25 @@ func _generate_offerings() -> void:
 		_refresh_shop_display()
 		return
 
+	if _is_active_run_shop_node():
+		var node_id := _active_shop_node_id()
+		var saved_state := GameManager.current_run.get_shop_state(node_id)
+		if not saved_state.is_empty():
+			_apply_shop_state(saved_state)
+			_refresh_shop_display()
+			return
+		_reroll_count = 0
+		_shop_generator.set_seed(_shop_seed_for(node_id, _reroll_count))
+		_generate_random_offerings()
+		_persist_shop_state()
+		return
+
+	_generate_random_offerings()
+
+
+func _generate_random_offerings() -> void:
+	_shop_offerings.clear()
+	_sold.clear()
 	var catalogue := DataManager.get_shop_catalogue()
 	if catalogue.is_empty():
 		return
@@ -249,6 +271,37 @@ func _generate_offerings() -> void:
 		_sold.append(false)
 
 	_refresh_shop_display()
+
+
+func _apply_shop_state(state: Dictionary) -> void:
+	_shop_offerings.clear()
+	_sold.clear()
+	_reroll_count = int(state.get("reroll_count", 0))
+	var raw_offerings: Array = state.get("offerings", [])
+	for item in raw_offerings:
+		if item is Dictionary:
+			_shop_offerings.append(item.duplicate(true))
+	var raw_sold: Array = state.get("sold", [])
+	for i in range(_shop_offerings.size()):
+		_sold.append(bool(raw_sold[i]) if i < raw_sold.size() else false)
+
+
+func _persist_shop_state() -> void:
+	if not _is_active_run_shop_node():
+		return
+	(
+		GameManager
+		. current_run
+		. set_shop_state(
+			_active_shop_node_id(),
+			{
+				"offerings": _shop_offerings.duplicate(true),
+				"sold": _sold.duplicate(),
+				"reroll_count": _reroll_count,
+			}
+		)
+	)
+	GameManager.save_game()
 
 
 func _refresh_shop_display() -> void:
@@ -348,7 +401,13 @@ func _on_reroll_pressed() -> void:
 		return
 	GameManager.coins -= REROLL_COST
 	GameManager.coins_changed.emit(GameManager.coins)
-	_generate_offerings()
+	if _is_active_run_shop_node():
+		_reroll_count += 1
+		_shop_generator.set_seed(_shop_seed_for(_active_shop_node_id(), _reroll_count))
+		_generate_random_offerings()
+		_persist_shop_state()
+	else:
+		_generate_offerings()
 	_update_coins()
 
 
@@ -357,7 +416,43 @@ func _on_ready_pressed() -> void:
 		return
 	if TutorialManager.is_active():
 		TutorialManager.report_action("go_to_dice_select")
-	GameManager.go_to_dice_select()
+		GameManager.go_to_dice_select()
+		return
+	GameManager.flea_market_continue()
+
+
+func _go_to_main_menu() -> void:
+	if GameManager.current_run != null:
+		GameManager.abandon_run()
+	GameManager.go_to_main_menu()
+
+
+func _update_ready_button_label() -> void:
+	if _ready_btn == null:
+		return
+	_ready_btn.text = "CONTINUE" if _is_active_run_shop_node() else "READY!"
+
+
+func _is_active_run_shop_node() -> bool:
+	if GameManager.current_run == null:
+		return false
+	var node: MapNodeRef = GameManager.current_run.get_current_node()
+	return node != null and node.type == MapNodeRef.NodeType.SHOP
+
+
+func _active_shop_node_id() -> int:
+	if GameManager.current_run == null:
+		return -1
+	var node: MapNodeRef = GameManager.current_run.get_current_node()
+	if node == null or node.type != MapNodeRef.NodeType.SHOP:
+		return -1
+	return node.id
+
+
+func _shop_seed_for(node_id: int, reroll_count: int) -> int:
+	if GameManager.current_run == null:
+		return 0
+	return abs(hash("%d:%d:%d" % [GameManager.current_run.seed, node_id, reroll_count]))
 
 
 func _on_my_dice_hover_enter() -> void:
@@ -435,6 +530,7 @@ func _on_shop_item_buy(index: int) -> void:
 			)
 		AudioManager.play_sfx(&"purchase")
 		_sold[index] = true
+		_persist_shop_state()
 		_desc_title.text = "Purchased!"
 		_desc_title.add_theme_color_override("default_color", GREEN)
 		_desc_rarity.text = ""
@@ -673,6 +769,7 @@ func _on_swap_face_selected(face_index: int) -> void:
 			TutorialManager.improved_die_index = selected_die_index
 		AudioManager.play_sfx(&"purchase")
 		_sold[shop_idx] = true
+		_persist_shop_state()
 		_desc_title.text = "Purchased!"
 		_desc_title.add_theme_color_override("default_color", GREEN)
 		_desc_rarity.text = ""
@@ -746,6 +843,7 @@ func _refresh_tutorial_ui() -> void:
 	if _tutorial_overlay == null:
 		return
 
+	_update_ready_button_label()
 	_ready_btn.disabled = TutorialManager.is_active() and not TutorialManager.can_go_to_dice_select()
 
 	if not TutorialManager.is_active() or TutorialManager.checkpoint_scene != TutorialManager.SCENE_FLEA_MARKET:

--- a/scenes/main_menu/main_menu.gd
+++ b/scenes/main_menu/main_menu.gd
@@ -16,6 +16,12 @@ const MAIN_MENU_VOLUME_LABEL_FONT_SIZE := 14
 const MAIN_MENU_VOLUME_LABEL_WIDTH := 120
 const MAIN_MENU_VOLUME_SLIDER_SIZE := Vector2(240, 32)
 const MAIN_MENU_SLIDER_GRABBER_SIZE := Vector2i(16, 24)
+const MAIN_MENU_RUN_RESULT_PANEL_SIZE := Vector2(480, 0)
+const MAIN_MENU_RUN_RESULT_SEPARATION := 24
+const MAIN_MENU_RUN_RESULT_TITLE_FONT_SIZE := 24
+const MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE := 14
+const MAIN_MENU_RUN_RESULT_BUTTON_SIZE := Vector2(220, 56)
+const MAIN_MENU_RUN_RESULT_BUTTON_FONT_SIZE := 16
 
 var _time := 0.0
 
@@ -35,6 +41,7 @@ var _sun_state := 0
 var _sun_textures: Array[Texture2D]
 
 var _settings_overlay: ColorRect
+var _run_result_overlay: ColorRect
 var _master_slider: HSlider
 var _music_slider: HSlider
 var _sfx_slider: HSlider
@@ -74,6 +81,11 @@ func _ready() -> void:
 		_connect_button_sfx(btn)
 
 	_build_settings_overlay()
+	if not GameManager.last_run_result.is_empty():
+		if GameManager.last_run_result.has("victory"):
+			_show_run_result_overlay(GameManager.last_run_result)
+		else:
+			GameManager.last_run_result = {}
 
 
 func _process(delta: float) -> void:
@@ -204,6 +216,13 @@ func _on_settings_tutorial_pressed() -> void:
 	GameManager.start_tutorial_replay()
 
 
+func _on_run_result_continue_pressed() -> void:
+	GameManager.last_run_result = {}
+	if _run_result_overlay != null:
+		_run_result_overlay.queue_free()
+		_run_result_overlay = null
+
+
 func _on_exit_pressed() -> void:
 	get_tree().quit()
 
@@ -264,6 +283,67 @@ func _build_settings_overlay() -> void:
 	)
 	close_btn.pressed.connect(_on_settings_close)
 	btn_center.add_child(close_btn)
+
+
+func _show_run_result_overlay(result: Dictionary) -> void:
+	if _run_result_overlay != null:
+		_run_result_overlay.queue_free()
+
+	_run_result_overlay = ColorRect.new()
+	_run_result_overlay.name = "RunResultOverlay"
+	_run_result_overlay.color = Color(0, 0, 0, 0.85)
+	_run_result_overlay.mouse_filter = Control.MOUSE_FILTER_STOP
+	_run_result_overlay.set_anchors_preset(Control.PRESET_FULL_RECT)
+	add_child(_run_result_overlay)
+
+	var center := CenterContainer.new()
+	center.set_anchors_preset(Control.PRESET_FULL_RECT)
+	_run_result_overlay.add_child(center)
+
+	var panel := _make_panel(DARK, GOLD, MAIN_MENU_RUN_RESULT_PANEL_SIZE, MAIN_MENU_SETTINGS_PANEL_MARGIN)
+	center.add_child(panel)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", MAIN_MENU_RUN_RESULT_SEPARATION)
+	panel.add_child(vbox)
+
+	var victory := bool(result.get("victory", false))
+	var title_text := "VICTORY" if victory else "DEFEAT"
+	var title_color := GOLD if victory else PINK
+	var title := _make_pixel_label(title_text, MAIN_MENU_RUN_RESULT_TITLE_FONT_SIZE, title_color)
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(title)
+
+	var round_label := _make_pixel_label(
+		"ROUND %d" % int(result.get("round", 0)), MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE
+	)
+	round_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(round_label)
+
+	var score := int(result.get("score", result.get("total_score", 0)))
+	var score_label := _make_pixel_label("SCORE %d" % score, MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE)
+	score_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(score_label)
+
+	var coins_label := _make_pixel_label(
+		"COINS %d" % int(result.get("coins", 0)), MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE
+	)
+	coins_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(coins_label)
+
+	var btn_center := CenterContainer.new()
+	vbox.add_child(btn_center)
+
+	var continue_btn := _make_colored_button(
+		"CONTINUE",
+		MAIN_MENU_RUN_RESULT_BUTTON_SIZE,
+		GREEN,
+		GREEN.lightened(0.15),
+		MAIN_MENU_RUN_RESULT_BUTTON_FONT_SIZE
+	)
+	continue_btn.name = "RunResultContinueButton"
+	continue_btn.pressed.connect(_on_run_result_continue_pressed)
+	btn_center.add_child(continue_btn)
 
 
 func _make_volume_row(parent: VBoxContainer, label_text: String, initial: float) -> HSlider:

--- a/scenes/map/map_node_button.gd
+++ b/scenes/map/map_node_button.gd
@@ -1,0 +1,222 @@
+extends Button
+class_name MapNodeButton
+
+signal node_clicked(node_id: int)
+
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+
+const DARK := Color("1a1a1a")
+const GOLD := Color("ffd700")
+const BORDER_BLACK := Color("000000")
+const BLUE := Color("4a9eff")
+const GREEN := Color("9acd32")
+const PINK := Color("ff69b4")
+const CARD_BG := Color("c8e6f5")
+const DISABLED_BG := Color("99a1af")
+const DISABLED_TEXT := Color("4a5565")
+const NODE_BORDER_WIDTH := 4
+const NODE_MARGIN := 8
+const NODE_FONT_SIZE := 14
+const NODE_CAPTION_FONT_SIZE := 7
+const ICON_VERTICAL_OFFSET := -7.0
+const ICON_DIE_SIZE := Vector2(20, 20)
+const ICON_SHOP_SIZE := Vector2(34, 30)
+const ICON_CROWN_SIZE := Vector2(34, 24)
+
+var node_id: int = -1
+var node_type: int = MapNodeRef.NodeType.COMBAT
+var state: String = "locked"
+var _pixel_font: Font
+
+
+func configure(p_id: int, p_type: int, p_state: String) -> void:
+	node_id = p_id
+	node_type = p_type
+	state = p_state
+	_apply_visual()
+	disabled = state != "available"
+	queue_redraw()
+
+
+func _ready() -> void:
+	_pixel_font = load("res://assets/fonts/PressStart2P-Regular.ttf")
+	pressed.connect(_on_pressed)
+	if custom_minimum_size == Vector2.ZERO:
+		custom_minimum_size = Vector2(56, 56)
+	_apply_visual()
+
+
+func _draw() -> void:
+	var icon_color := _icon_color()
+	match node_type:
+		MapNodeRef.NodeType.COMBAT:
+			_draw_rolling_dice_icon(icon_color)
+		MapNodeRef.NodeType.SHOP:
+			_draw_storefront_icon(icon_color)
+		MapNodeRef.NodeType.BOSS:
+			_draw_crown_icon(icon_color)
+	_draw_caption(icon_color)
+
+
+func _on_pressed() -> void:
+	if state == "available":
+		node_clicked.emit(node_id)
+
+
+func _apply_visual() -> void:
+	text = ""
+	tooltip_text = _label_for_type(node_type)
+	add_theme_font_override("font", _pixel_font)
+	add_theme_font_size_override("font_size", NODE_FONT_SIZE)
+
+	var bg := _bg_for_type(node_type)
+	var border := BORDER_BLACK
+	var font_col := DARK
+	if state == "locked":
+		bg = DISABLED_BG
+		border = Color(0.28, 0.31, 0.36)
+		font_col = DISABLED_TEXT
+	elif state == "completed":
+		bg = GREEN
+	elif state == "available":
+		border = GOLD
+
+	add_theme_stylebox_override("normal", _make_style(bg, border))
+	add_theme_stylebox_override("hover", _make_style(bg.lightened(0.12), border))
+	add_theme_stylebox_override("pressed", _make_style(bg.darkened(0.12), BORDER_BLACK))
+	add_theme_stylebox_override("disabled", _make_style(bg, border))
+	add_theme_stylebox_override("focus", _make_focus_style())
+
+	add_theme_color_override("font_color", font_col)
+	add_theme_color_override("font_hover_color", font_col)
+	add_theme_color_override("font_pressed_color", font_col)
+	add_theme_color_override("font_focus_color", font_col)
+	add_theme_color_override("font_disabled_color", font_col)
+	queue_redraw()
+
+
+func _make_style(bg_color: Color, border_color: Color) -> StyleBoxFlat:
+	var style := StyleBoxFlat.new()
+	style.bg_color = bg_color
+	style.border_color = border_color
+	style.set_border_width_all(NODE_BORDER_WIDTH)
+	style.set_corner_radius_all(0)
+	style.set_content_margin_all(NODE_MARGIN)
+	return style
+
+
+func _make_focus_style() -> StyleBoxFlat:
+	var style := _make_style(Color(0, 0, 0, 0), GOLD)
+	style.draw_center = false
+	return style
+
+
+func _bg_for_type(t: int) -> Color:
+	match t:
+		MapNodeRef.NodeType.COMBAT:
+			return CARD_BG
+		MapNodeRef.NodeType.SHOP:
+			return BLUE
+		MapNodeRef.NodeType.BOSS:
+			return PINK
+	return CARD_BG
+
+
+func _label_for_type(t: int) -> String:
+	match t:
+		MapNodeRef.NodeType.COMBAT:
+			return "Roll Dice"
+		MapNodeRef.NodeType.SHOP:
+			return "Shop"
+		MapNodeRef.NodeType.BOSS:
+			return "Boss"
+	return "Unknown"
+
+
+func get_visible_caption() -> String:
+	match node_type:
+		MapNodeRef.NodeType.COMBAT:
+			return "ROLL"
+		MapNodeRef.NodeType.SHOP:
+			return "SHOP"
+		MapNodeRef.NodeType.BOSS:
+			return "BOSS"
+	return "?"
+
+
+func _icon_color() -> Color:
+	if state == "locked":
+		return DISABLED_TEXT
+	return DARK
+
+
+func _draw_caption(icon_color: Color) -> void:
+	if _pixel_font == null:
+		return
+	draw_string(
+		_pixel_font,
+		Vector2(0, size.y - 7.0),
+		get_visible_caption(),
+		HORIZONTAL_ALIGNMENT_CENTER,
+		size.x,
+		NODE_CAPTION_FONT_SIZE,
+		icon_color
+	)
+
+
+func _draw_rolling_dice_icon(icon_color: Color) -> void:
+	var center := size * 0.5 + Vector2(0, ICON_VERTICAL_OFFSET)
+	draw_arc(center, 18.0, PI * 1.05, PI * 1.65, 10, icon_color, 2.0)
+	draw_line(center + Vector2(-16, -3), center + Vector2(-20, 1), icon_color, 2.0)
+	draw_line(center + Vector2(-16, -3), center + Vector2(-11, -1), icon_color, 2.0)
+	_draw_die(Vector2(center.x - 22, center.y - 8), icon_color, [Vector2(6, 6), Vector2(14, 14)])
+	_draw_die(Vector2(center.x + 2, center.y - 12), icon_color, [Vector2(5, 5), Vector2(10, 10), Vector2(15, 15)])
+
+
+func _draw_die(origin: Vector2, icon_color: Color, pips: Array[Vector2]) -> void:
+	var rect := Rect2(origin, ICON_DIE_SIZE)
+	draw_rect(rect, Color.WHITE)
+	draw_rect(rect.grow(-3), Color("e4e4e4"))
+	draw_rect(rect, icon_color, false, 4.0)
+	for pip in pips:
+		draw_rect(Rect2(origin + pip - Vector2(2, 2), Vector2(4, 4)), icon_color)
+
+
+func _draw_storefront_icon(icon_color: Color) -> void:
+	var origin := (size - ICON_SHOP_SIZE) * 0.5 + Vector2(0, ICON_VERTICAL_OFFSET)
+	var body := Rect2(origin + Vector2(2, 11), Vector2(30, 19))
+	var awning := Rect2(origin, Vector2(34, 12))
+	var counter := Rect2(origin + Vector2(5, 17), Vector2(13, 8))
+	var door := Rect2(origin + Vector2(22, 17), Vector2(7, 13))
+
+	draw_rect(body, Color("f6f1dc"))
+	draw_rect(body, icon_color, false, 4.0)
+	draw_rect(awning, Color.WHITE)
+	draw_rect(Rect2(origin, Vector2(7, 12)), GOLD)
+	draw_rect(Rect2(origin + Vector2(14, 0), Vector2(7, 12)), GOLD)
+	draw_rect(Rect2(origin + Vector2(28, 0), Vector2(6, 12)), GOLD)
+	draw_rect(awning, icon_color, false, 3.0)
+	draw_rect(counter, Color("9ce1ff"))
+	draw_rect(counter, icon_color, false, 3.0)
+	draw_rect(door, Color("d89b64"))
+	draw_rect(door, icon_color, false, 3.0)
+	draw_rect(Rect2(origin + Vector2(5, 28), Vector2(24, 3)), icon_color)
+
+
+func _draw_crown_icon(icon_color: Color) -> void:
+	var origin := (size - ICON_CROWN_SIZE) * 0.5 + Vector2(0, ICON_VERTICAL_OFFSET)
+	var base_y := origin.y + ICON_CROWN_SIZE.y
+	var points := PackedVector2Array(
+		[
+			Vector2(origin.x, base_y),
+			Vector2(origin.x + 4, origin.y + 8),
+			Vector2(origin.x + 12, origin.y + 14),
+			Vector2(origin.x + 17, origin.y),
+			Vector2(origin.x + 22, origin.y + 14),
+			Vector2(origin.x + 30, origin.y + 8),
+			Vector2(origin.x + 34, base_y),
+		]
+	)
+	draw_colored_polygon(points, GOLD)
+	draw_polyline(points, icon_color, 4.0)
+	draw_line(Vector2(origin.x + 4, base_y), Vector2(origin.x + 30, base_y), icon_color, 4.0)

--- a/scenes/map/map_node_button.gd.uid
+++ b/scenes/map/map_node_button.gd.uid
@@ -1,0 +1,1 @@
+uid://es0ogf0tkuy1

--- a/scenes/map/map_node_button.tscn
+++ b/scenes/map/map_node_button.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/map/map_node_button.gd" id="1"]
+
+[node name="MapNodeButton" type="Button"]
+custom_minimum_size = Vector2(56, 56)
+text = "?"
+script = ExtResource("1")

--- a/scenes/map/map_screen.gd
+++ b/scenes/map/map_screen.gd
@@ -1,0 +1,365 @@
+extends "res://scripts/ui/pixel_bg.gd"
+
+const MapNodeButtonScene := preload("res://scenes/map/map_node_button.tscn")
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+
+const MAP_CONTENT_SEPARATION := 32
+const MAP_TOP_BAR_SEPARATION := 16
+const MAP_PANEL_SIZE := Vector2(980, 520)
+const MAP_PANEL_MIN_SIZE := Vector2(560, 300)
+const MAP_PANEL_MARGIN := 16
+const MAP_NODE_SIZE := Vector2(56, 56)
+const MAP_NODE_SHADOW_OFFSET := Vector2(5, 5)
+const MAP_LEVEL_PADDING_TOP := 72.0
+const MAP_LEVEL_PADDING_BOTTOM := 72.0
+const MAP_LEVEL_SPACING := 152.0
+const MAP_NODE_SIDE_PADDING := 140.0
+const MAP_NODE_SPACING := 176.0
+const MAP_COIN_PANEL_SIZE := Vector2(124, 48)
+const MAP_COIN_ROW_SEPARATION := 8
+const MAP_COIN_LABEL_FONT_SIZE := 16
+const MAP_COIN_ICON_SIZE := Vector2(24, 24)
+const MAP_START_NODE_ID := -1000
+const EDGE_COLOR_DIM := Color(0.1, 0.1, 0.1, 0.45)
+const EDGE_COLOR_AVAILABLE := Color("ffd700")
+const EDGE_COLOR_COMPLETED := Color("9acd32")
+
+var _coin_label: Label
+var _map_container: Control
+var _map_panel: PanelContainer
+var _map_scroll: ScrollContainer
+var _all_buttons: Array = []
+
+var _button_by_id: Dictionary = {}
+var _position_by_id: Dictionary = {}
+
+
+func _ready() -> void:
+	super._ready()
+	_build_ui()
+	_update_coins()
+	_render_map()
+	_map_container.draw.connect(_draw_edges)
+	GameManager.coins_changed.connect(func(_amount: int): _update_coins())
+	AudioManager.play_music(&"menu")
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_RESIZED and is_instance_valid(_map_panel):
+		_refresh_map_layout()
+
+
+func _draw() -> void:
+	_draw_all_bg()
+	_draw_button_shadows(_all_buttons, Vector2(4, 4))
+
+
+func _build_ui() -> void:
+	var layout := _make_screen_layout(MAP_CONTENT_SEPARATION, true)
+	var content: VBoxContainer = layout["content"]
+
+	_build_top_bar(content)
+	_build_map_panel(content)
+
+
+func _build_top_bar(parent: VBoxContainer) -> void:
+	var bar := HBoxContainer.new()
+	bar.add_theme_constant_override("separation", MAP_TOP_BAR_SEPARATION)
+	bar.alignment = BoxContainer.ALIGNMENT_CENTER
+	parent.add_child(bar)
+
+	var left_box := HBoxContainer.new()
+	left_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	bar.add_child(left_box)
+
+	var menu_btn := _make_menu_button()
+	menu_btn.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+	left_box.add_child(menu_btn)
+	_all_buttons.append(menu_btn)
+
+	bar.add_child(_make_title_bar("MAP"))
+
+	var right_wrapper := HBoxContainer.new()
+	right_wrapper.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	right_wrapper.alignment = BoxContainer.ALIGNMENT_END
+	bar.add_child(right_wrapper)
+
+	var coin_panel := _make_panel(GOLD, BORDER_BLACK, MAP_COIN_PANEL_SIZE)
+	right_wrapper.add_child(coin_panel)
+
+	var coin_hbox := HBoxContainer.new()
+	coin_hbox.add_theme_constant_override("separation", MAP_COIN_ROW_SEPARATION)
+	coin_hbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	coin_panel.add_child(coin_hbox)
+
+	coin_hbox.add_child(_create_coin_icon())
+
+	_coin_label = _make_pixel_label("", MAP_COIN_LABEL_FONT_SIZE)
+	coin_hbox.add_child(_coin_label)
+
+
+func _build_map_panel(parent: VBoxContainer) -> void:
+	var center := CenterContainer.new()
+	center.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	parent.add_child(center)
+
+	_map_panel = _make_panel(CARD_BG, BORDER_BLACK, MAP_PANEL_SIZE, MAP_PANEL_MARGIN)
+	_map_panel.custom_minimum_size = _target_map_panel_size(get_viewport_rect().size)
+	center.add_child(_map_panel)
+
+	_map_scroll = ScrollContainer.new()
+	_map_scroll.name = "MapScroll"
+	_map_scroll.custom_minimum_size = (
+		_map_panel.custom_minimum_size - Vector2(MAP_PANEL_MARGIN * 2, MAP_PANEL_MARGIN * 2)
+	)
+	_map_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_map_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_map_panel.add_child(_map_scroll)
+
+	_map_container = Control.new()
+	_map_container.name = "MapContainer"
+	_map_container.unique_name_in_owner = true
+	_map_container.custom_minimum_size = _map_scroll.custom_minimum_size
+	_map_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_map_container.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
+	_map_scroll.add_child(_map_container)
+	_map_container.owner = self
+
+
+func _create_coin_icon() -> TextureRect:
+	var rect := TextureRect.new()
+	rect.texture = preload("res://assets/art/ui/coin.png")
+	rect.custom_minimum_size = MAP_COIN_ICON_SIZE
+	rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	return rect
+
+
+func _target_map_panel_size(viewport_size: Vector2) -> Vector2:
+	var max_width := viewport_size.x - SCREEN_MARGIN_LEFT - SCREEN_MARGIN_RIGHT
+	var max_height := viewport_size.y - SCREEN_MARGIN_TOP - SCREEN_MARGIN_BOTTOM - MAP_CONTENT_SEPARATION - 96.0
+	return Vector2(
+		clampf(MAP_PANEL_SIZE.x, MAP_PANEL_MIN_SIZE.x, max_width),
+		clampf(MAP_PANEL_SIZE.y, MAP_PANEL_MIN_SIZE.y, max_height)
+	)
+
+
+func _target_map_content_size(depth_count: int, viewport_size: Vector2) -> Vector2:
+	var visible_panel_size := _target_map_panel_size(viewport_size)
+	var visible_content_size := visible_panel_size - Vector2(MAP_PANEL_MARGIN * 2, MAP_PANEL_MARGIN * 2)
+	var tall_path_height: float = (
+		MAP_LEVEL_PADDING_TOP + MAP_LEVEL_PADDING_BOTTOM + MAP_NODE_SIZE.y + max(0, depth_count - 1) * MAP_LEVEL_SPACING
+	)
+	return Vector2(visible_content_size.x, maxf(visible_content_size.y, tall_path_height))
+
+
+func _update_coins() -> void:
+	if _coin_label:
+		_coin_label.text = str(GameManager.coins)
+
+
+func _refresh_map_layout() -> void:
+	_map_panel.custom_minimum_size = _target_map_panel_size(get_viewport_rect().size)
+	_map_scroll.custom_minimum_size = (
+		_map_panel.custom_minimum_size - Vector2(MAP_PANEL_MARGIN * 2, MAP_PANEL_MARGIN * 2)
+	)
+	_map_container.custom_minimum_size = _map_scroll.custom_minimum_size
+	_render_map()
+
+
+func _render_map() -> void:
+	for child in _map_container.get_children():
+		child.queue_free()
+	_button_by_id.clear()
+	_position_by_id.clear()
+
+	var run := GameManager.current_run
+	if run == null:
+		_map_container.queue_redraw()
+		queue_redraw()
+		return
+
+	var levels: Dictionary = {}
+	for id_key in run.nodes.keys():
+		var node: MapNodeRef = run.nodes[id_key]
+		if not levels.has(node.depth):
+			levels[node.depth] = []
+		levels[node.depth].append(node)
+
+	var depths := levels.keys()
+	depths.sort()
+	var min_depth := int(depths[0])
+	var max_depth := int(depths[depths.size() - 1])
+	var layout_min_depth := min_depth - 1
+	_map_container.custom_minimum_size = _target_map_content_size(
+		max_depth - layout_min_depth + 1, get_viewport_rect().size
+	)
+	var container_width := maxf(_map_container.size.x, _map_container.custom_minimum_size.x)
+	var container_height := maxf(_map_container.size.y, _map_container.custom_minimum_size.y)
+	var usable_height := maxf(
+		1.0, container_height - MAP_LEVEL_PADDING_TOP - MAP_LEVEL_PADDING_BOTTOM - MAP_NODE_SIZE.y
+	)
+
+	for depth in depths:
+		var level: Array = levels[depth]
+		level.sort_custom(func(a: MapNodeRef, b: MapNodeRef) -> bool: return a.id < b.id)
+		var count := level.size()
+		for index in range(count):
+			var node: MapNodeRef = level[index]
+			var x := _x_for_node(index, count, container_width)
+			var y := _y_for_depth(int(depth), layout_min_depth, max_depth, usable_height)
+			var btn: MapNodeButton = MapNodeButtonScene.instantiate()
+			_map_container.add_child(btn)
+			btn.position = Vector2(x, y)
+			btn.custom_minimum_size = MAP_NODE_SIZE
+			btn.configure(node.id, node.type, _state_for(node, run))
+			btn.node_clicked.connect(_on_node_clicked)
+			_button_by_id[node.id] = btn
+			_position_by_id[node.id] = btn.position + btn.custom_minimum_size * 0.5
+
+	_add_start_node(layout_min_depth, max_depth, container_width, usable_height)
+
+	_map_container.queue_redraw()
+	queue_redraw()
+	call_deferred("_scroll_to_relevant_node")
+
+
+func _x_for_node(index: int, count: int, container_width: float) -> float:
+	var center_x := container_width * 0.5 - MAP_NODE_SIZE.x * 0.5
+	if count <= 1:
+		return center_x
+	var total_width := minf(float(count - 1) * MAP_NODE_SPACING, container_width - MAP_NODE_SIDE_PADDING * 2.0)
+	var step := total_width / float(count - 1)
+	return center_x - total_width * 0.5 + float(index) * step
+
+
+func _y_for_depth(depth: int, min_depth: int, max_depth: int, usable_height: float) -> float:
+	if max_depth <= min_depth:
+		return MAP_LEVEL_PADDING_TOP + usable_height
+	var progress := float(depth - min_depth) / float(max_depth - min_depth)
+	return MAP_LEVEL_PADDING_TOP + (1.0 - progress) * usable_height
+
+
+func _state_for(node: MapNodeRef, run) -> String:
+	if run.has_completed(node.id):
+		return "completed"
+	if run.available_node_ids().has(node.id):
+		return "available"
+	return "locked"
+
+
+func _on_node_clicked(node_id: int) -> void:
+	GameManager.enter_map_node(node_id)
+
+
+func _go_to_main_menu() -> void:
+	if GameManager.current_run != null:
+		GameManager.abandon_run()
+	GameManager.go_to_main_menu()
+
+
+func _add_start_node(layout_min_depth: int, max_depth: int, container_width: float, usable_height: float) -> void:
+	var btn: MapNodeButton = MapNodeButtonScene.instantiate()
+	_map_container.add_child(btn)
+	var x := _x_for_node(0, 1, container_width)
+	var y := _y_for_depth(layout_min_depth, layout_min_depth, max_depth, usable_height)
+	btn.position = Vector2(x, y)
+	btn.custom_minimum_size = MAP_NODE_SIZE
+	btn.configure(MAP_START_NODE_ID, MapNodeRef.NodeType.COMBAT, "completed")
+	_button_by_id[MAP_START_NODE_ID] = btn
+	_position_by_id[MAP_START_NODE_ID] = btn.position + btn.custom_minimum_size * 0.5
+
+
+func _draw_edges() -> void:
+	var run := GameManager.current_run
+	if run == null:
+		return
+
+	var available := run.available_node_ids()
+	_draw_node_shadows()
+	_draw_start_edges(run, available)
+	for id_key in run.nodes.keys():
+		var node: MapNodeRef = run.nodes[id_key]
+		if not _position_by_id.has(node.id):
+			continue
+		var from_pos: Vector2 = _position_by_id[node.id]
+		for next_id in node.next_ids:
+			var next_node_id := int(next_id)
+			if not _position_by_id.has(next_node_id):
+				continue
+			var to_pos: Vector2 = _position_by_id[next_node_id]
+			var col := _edge_color_for(node, next_node_id, run, available)
+			_map_container.draw_line(from_pos + Vector2(2, 2), to_pos + Vector2(2, 2), SHADOW_COLOR, 6.0)
+			_map_container.draw_line(from_pos, to_pos, col, 4.0)
+
+
+func _edge_color_for(node: MapNodeRef, next_node_id: int, run, available: Array[int]) -> Color:
+	if node.id == run.current_node_id and available.has(next_node_id):
+		return EDGE_COLOR_AVAILABLE
+	if run.has_completed(node.id) and run.has_completed(next_node_id):
+		return EDGE_COLOR_COMPLETED
+	return EDGE_COLOR_DIM
+
+
+func _draw_start_edges(run, available: Array[int]) -> void:
+	if not _position_by_id.has(MAP_START_NODE_ID):
+		return
+	var start_pos: Vector2 = _position_by_id[MAP_START_NODE_ID]
+	for id_key in run.nodes.keys():
+		var node: MapNodeRef = run.nodes[id_key]
+		if node.depth != 1 or not _position_by_id.has(node.id):
+			continue
+		var to_pos: Vector2 = _position_by_id[node.id]
+		var col := EDGE_COLOR_DIM
+		if run.has_completed(node.id):
+			col = EDGE_COLOR_COMPLETED
+		elif available.has(node.id):
+			col = EDGE_COLOR_AVAILABLE
+		_map_container.draw_line(start_pos + Vector2(2, 2), to_pos + Vector2(2, 2), SHADOW_COLOR, 6.0)
+		_map_container.draw_line(start_pos, to_pos, col, 4.0)
+
+
+func _draw_node_shadows() -> void:
+	for id_key in _button_by_id.keys():
+		var btn: Button = _button_by_id[id_key]
+		if not is_instance_valid(btn):
+			continue
+		_map_container.draw_rect(Rect2(btn.position + MAP_NODE_SHADOW_OFFSET, btn.size), SHADOW_COLOR)
+
+
+func _scroll_to_bottom() -> void:
+	if not is_instance_valid(_map_scroll):
+		return
+	var scrollbar := _map_scroll.get_v_scroll_bar()
+	_map_scroll.scroll_vertical = int(scrollbar.max_value)
+
+
+func _scroll_to_relevant_node() -> void:
+	if not is_instance_valid(_map_scroll):
+		return
+	var run := GameManager.current_run
+	if run == null:
+		return
+	var target_id := _scroll_target_node_id(run)
+	if not _position_by_id.has(target_id):
+		_scroll_to_bottom()
+		return
+
+	var target_position: Vector2 = _position_by_id[target_id]
+	var visible_height := _map_scroll.size.y
+	if visible_height <= 0.0:
+		visible_height = _map_scroll.custom_minimum_size.y
+	var scrollbar := _map_scroll.get_v_scroll_bar()
+	var target_scroll := target_position.y - visible_height * 0.5
+	_map_scroll.scroll_vertical = int(clampf(target_scroll, 0.0, scrollbar.max_value))
+
+
+func _scroll_target_node_id(run) -> int:
+	if run.current_node_id == -1:
+		return MAP_START_NODE_ID
+	var available: Array[int] = run.available_node_ids()
+	if not available.is_empty():
+		available.sort()
+		return available[0]
+	return int(run.current_node_id)

--- a/scenes/map/map_screen.gd.uid
+++ b/scenes/map/map_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://ocb7srxb0xnu

--- a/scenes/map/map_screen.tscn
+++ b/scenes/map/map_screen.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/map/map_screen.gd" id="1"]
+
+[node name="MapScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")

--- a/scripts/autoload/data_manager.gd
+++ b/scripts/autoload/data_manager.gd
@@ -3,12 +3,23 @@ extends Node
 var _faces: Dictionary = {}
 var _shop_catalogue: Array = []
 var _combo_rules: Array = []
+var _map_config: Dictionary = {}
+
+const MAP_CONFIG_DEFAULTS := {
+	"depth": 10,
+	"min_nodes_per_level": 1,
+	"max_nodes_per_level": 3,
+	"shop_probability": 0.3,
+	"max_consecutive_shops": 2,
+	"boss_blind_multiplier": 1.5,
+}
 
 
 func _ready() -> void:
 	_load_faces()
 	_load_shop_catalogue()
 	_load_combo_rules()
+	_load_map_config()
 
 
 func _load_json(path: String) -> Variant:
@@ -46,6 +57,46 @@ func _load_combo_rules() -> void:
 		_combo_rules = data
 
 
+func _load_map_config() -> void:
+	var data = _load_json("res://resources/data/map_config.json")
+	if data is Dictionary:
+		_map_config = _validated_map_config(data)
+	else:
+		push_error("map_config.json missing or malformed; using defaults")
+		_map_config = MAP_CONFIG_DEFAULTS.duplicate()
+
+
+func _validated_map_config(raw: Dictionary) -> Dictionary:
+	var cfg := MAP_CONFIG_DEFAULTS.duplicate()
+	for key in MAP_CONFIG_DEFAULTS.keys():
+		if raw.has(key):
+			cfg[key] = raw[key]
+
+	if int(cfg["depth"]) < 2:
+		push_error("map_config.depth must be >= 2; using default")
+		cfg["depth"] = MAP_CONFIG_DEFAULTS["depth"]
+	if int(cfg["min_nodes_per_level"]) < 1:
+		push_error("map_config.min_nodes_per_level must be >= 1; using default")
+		cfg["min_nodes_per_level"] = MAP_CONFIG_DEFAULTS["min_nodes_per_level"]
+	if int(cfg["max_nodes_per_level"]) < int(cfg["min_nodes_per_level"]):
+		push_error("map_config.max_nodes_per_level must be >= min_nodes_per_level; using defaults")
+		cfg["min_nodes_per_level"] = MAP_CONFIG_DEFAULTS["min_nodes_per_level"]
+		cfg["max_nodes_per_level"] = MAP_CONFIG_DEFAULTS["max_nodes_per_level"]
+
+	var shop_prob := float(cfg["shop_probability"])
+	if shop_prob < 0.0 or shop_prob > 1.0:
+		push_error("map_config.shop_probability must be in [0,1]; using default")
+		cfg["shop_probability"] = MAP_CONFIG_DEFAULTS["shop_probability"]
+	if int(cfg["max_consecutive_shops"]) < 0:
+		push_error("map_config.max_consecutive_shops must be >= 0; using default")
+		cfg["max_consecutive_shops"] = MAP_CONFIG_DEFAULTS["max_consecutive_shops"]
+	if float(cfg["boss_blind_multiplier"]) < 1.0:
+		push_error("map_config.boss_blind_multiplier must be >= 1.0; using default")
+		cfg["boss_blind_multiplier"] = MAP_CONFIG_DEFAULTS["boss_blind_multiplier"]
+
+	return cfg
+
+
 func _dict_to_face(d: Dictionary) -> DiceFace:
 	return (
 		DiceFace
@@ -77,6 +128,10 @@ func get_shop_catalogue() -> Array:
 
 func get_combo_rules() -> Array:
 	return _combo_rules
+
+
+func get_map_config() -> Dictionary:
+	return _map_config.duplicate()
 
 
 func create_basic_faces() -> Array[DiceFace]:

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -1,6 +1,10 @@
 extends Node
 
-enum Phase { MAIN_MENU, FLEA_MARKET, DICE_SELECT, COMBAT }
+const RunState := preload("res://scripts/map/run_state.gd")
+const MapGeneratorRef := preload("res://scripts/map/map_generator.gd")
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+
+enum Phase { MAIN_MENU, FLEA_MARKET, DICE_SELECT, COMBAT, MAP }
 
 const SAVE_PATH := "user://save_game.json"
 const APP_VERSION_SETTING := "application/config/version"
@@ -23,10 +27,13 @@ var hands_per_round: int = 4
 var rerolls_per_hand: int = 3
 var selected_dice: Array[Die] = []
 var current_round: int = 1
+var current_run: RunState = null
+var last_run_result: Dictionary = {}
 const BASE_TARGET: int = 150
 var save_path: String = SAVE_PATH
 var _last_tutorial_completed: bool = false
 var _last_tutorial_active: bool = false
+var _pending_combat_result_phase: int = -1
 
 
 func _ready() -> void:
@@ -38,6 +45,8 @@ func _ready() -> void:
 func start_game(skip_tutorial_intro: bool = false) -> void:
 	delete_save()
 	_reset_run_state()
+	current_run = MapGeneratorRef.generate(randi(), DataManager.get_map_config())
+	last_run_result = {}
 	if skip_tutorial_intro:
 		TutorialManager.clear_active_tutorial()
 	elif TutorialManager.should_auto_start_on_new_game():
@@ -54,12 +63,14 @@ func start_game(skip_tutorial_intro: bool = false) -> void:
 		_setup_intro_combat()
 		_change_phase(Phase.COMBAT)
 	else:
-		_change_phase(Phase.FLEA_MARKET)
+		_change_phase(Phase.MAP)
 
 
 func start_tutorial_replay() -> void:
 	delete_save()
 	_reset_run_state()
+	current_run = null
+	last_run_result = {}
 	TutorialManager.start_replay()
 	_setup_intro_combat()
 	AudioManager.pause_for_ad()
@@ -73,8 +84,10 @@ func skip_active_tutorial() -> void:
 	if not TutorialManager.is_active():
 		return
 	_reset_run_state()
+	current_run = MapGeneratorRef.generate(randi(), DataManager.get_map_config())
+	last_run_result = {}
 	TutorialManager.complete_tutorial()
-	_change_phase(Phase.FLEA_MARKET)
+	_change_phase(Phase.MAP)
 
 
 func _setup_intro_combat() -> void:
@@ -87,6 +100,7 @@ func _setup_intro_combat() -> void:
 
 
 func _reset_run_state() -> void:
+	clear_resolved_combat_result()
 	coins = STARTING_COINS
 	total_score = 0
 	current_round = 1
@@ -170,28 +184,175 @@ func go_to_dice_select() -> void:
 	_change_phase(Phase.DICE_SELECT)
 
 
+func flea_market_continue() -> void:
+	if current_run == null:
+		_change_phase(Phase.DICE_SELECT)
+		return
+	var node: MapNodeRef = current_run.get_current_node()
+	if node == null:
+		push_warning("Unexpected Flea Market continue before selecting a map node.")
+		_change_phase(Phase.MAP)
+		return
+	if node.type == MapNodeRef.NodeType.SHOP:
+		complete_current_node()
+		return
+	push_warning("Unexpected Flea Market continue from non-shop map node %d." % node.id)
+	_change_phase(Phase.MAP)
+
+
 func end_combat(final_score: int, target_beaten: bool) -> void:
+	var destination := _apply_combat_result_state(final_score, target_beaten)
+	_change_phase(destination)
+
+
+func resolve_combat_result_for_overlay(final_score: int, target_beaten: bool) -> Phase:
+	if _pending_combat_result_phase >= 0:
+		return _pending_combat_result_phase as Phase
+	var destination := _apply_combat_result_state(final_score, target_beaten)
+	_pending_combat_result_phase = destination
+	if destination == Phase.MAIN_MENU:
+		delete_save()
+	else:
+		save_game()
+	return destination
+
+
+func finish_resolved_combat_result() -> void:
+	if _pending_combat_result_phase < 0:
+		return
+	var destination := _pending_combat_result_phase as Phase
+	_pending_combat_result_phase = -1
+	_change_phase(destination)
+
+
+func has_resolved_combat_result() -> bool:
+	return _pending_combat_result_phase >= 0
+
+
+func clear_resolved_combat_result() -> void:
+	_pending_combat_result_phase = -1
+
+
+func _apply_combat_result_state(final_score: int, target_beaten: bool) -> Phase:
 	total_score = final_score
 	score_changed.emit(total_score)
 	PokiSDK.gameplay_stop()
+	if TutorialManager.is_active() and TutorialManager.is_intro_step():
+		if target_beaten:
+			_apply_round_advance()
+			return Phase.FLEA_MARKET
+		return Phase.MAIN_MENU
+	if current_run != null:
+		if current_run.current_node_id == -1:
+			if target_beaten:
+				return Phase.MAP
+			_apply_end_run(false)
+			return Phase.MAIN_MENU
+		if target_beaten:
+			return _apply_current_node_completion_state()
+		_apply_end_run(false)
+		return Phase.MAIN_MENU
 	if target_beaten:
-		advance_round()
-	else:
-		go_to_main_menu()
+		_apply_round_advance()
+		return Phase.FLEA_MARKET
+	return Phase.MAIN_MENU
 
 
-func advance_round() -> void:
+func _apply_round_advance() -> void:
 	var reward := 10 + 5 * current_round
 	coins += reward
 	coins_changed.emit(coins)
 	current_round += 1
 	target_score = int(floor(BASE_TARGET * pow(1.5, current_round - 1)))
 	selected_dice.clear()
+
+
+func advance_round() -> void:
+	_apply_round_advance()
 	_change_phase(Phase.FLEA_MARKET)
+
+
+func complete_current_node() -> void:
+	var destination := _apply_current_node_completion_state()
+	if destination >= 0:
+		_change_phase(destination as Phase)
+
+
+func _apply_current_node_completion_state() -> int:
+	if current_run == null:
+		push_warning("Cannot complete a map node without an active run.")
+		return -1
+	var node: MapNodeRef = current_run.get_current_node()
+	if node == null:
+		push_warning("Cannot complete a map node before one is selected.")
+		return -1
+	match node.type:
+		MapNodeRef.NodeType.COMBAT:
+			current_run.complete_current_node()
+			_apply_round_advance()
+			return Phase.MAP
+		MapNodeRef.NodeType.SHOP:
+			current_run.complete_current_node()
+			return Phase.MAP
+		MapNodeRef.NodeType.BOSS:
+			current_run.complete_current_node()
+			_apply_round_reward()
+			selected_dice.clear()
+			_apply_end_run(true)
+			return Phase.MAIN_MENU
+	return -1
+
+
+func enter_map_node(node_id: int) -> void:
+	if current_run == null:
+		push_warning("Cannot enter a map node without an active run.")
+		return
+	var available := current_run.available_node_ids()
+	if not available.has(node_id):
+		push_warning("Cannot enter unavailable map node %d." % node_id)
+		return
+	current_run.enter_node(node_id)
+	var node: MapNodeRef = current_run.nodes[node_id]
+	if node.type == MapNodeRef.NodeType.BOSS:
+		var boss_multiplier := float(DataManager.get_map_config().get("boss_blind_multiplier", 1.5))
+		target_score = int(floor(float(target_score) * boss_multiplier))
+	match node.type:
+		MapNodeRef.NodeType.COMBAT, MapNodeRef.NodeType.BOSS:
+			_change_phase(Phase.DICE_SELECT)
+		MapNodeRef.NodeType.SHOP:
+			_change_phase(Phase.FLEA_MARKET)
+
+
+func end_run(victory: bool) -> void:
+	_apply_end_run(victory)
+	_change_phase(Phase.MAIN_MENU)
+
+
+func _apply_end_run(victory: bool) -> void:
+	last_run_result = {
+		"victory": victory,
+		"round": current_round,
+		"total_score": total_score,
+		"coins": coins,
+	}
+	current_run = null
+	delete_save()
+
+
+func abandon_run() -> void:
+	clear_resolved_combat_result()
+	current_run = null
+	last_run_result = {}
+	delete_save()
 
 
 func get_round_reward() -> int:
 	return 10 + 5 * current_round
+
+
+func _apply_round_reward() -> void:
+	coins += get_round_reward()
+	coins_changed.emit(coins)
 
 
 func get_app_version() -> String:
@@ -222,6 +383,7 @@ func _change_phase(new_phase: Phase) -> void:
 	phase_changed.emit(new_phase)
 	if new_phase != Phase.MAIN_MENU:
 		save_game()
+	_pending_combat_result_phase = -1
 
 	if new_phase == Phase.MAIN_MENU and old_phase != Phase.MAIN_MENU:
 		AudioManager.pause_for_ad()
@@ -240,6 +402,8 @@ func _change_phase(new_phase: Phase) -> void:
 		Phase.COMBAT:
 			get_tree().change_scene_to_file("res://scenes/combat/combat_screen.tscn")
 			PokiSDK.gameplay_start()
+		Phase.MAP:
+			get_tree().change_scene_to_file("res://scenes/map/map_screen.tscn")
 
 
 # -- Save / Load ---------------------------------------------------------------
@@ -255,10 +419,15 @@ func can_load_save(path_override: String = "") -> bool:
 
 func build_save_data() -> Dictionary:
 	var save_phase := current_phase
-	if save_phase == Phase.COMBAT and not TutorialManager.is_active():
-		save_phase = Phase.FLEA_MARKET
+	if _pending_combat_result_phase >= 0:
+		save_phase = _pending_combat_result_phase as Phase
+	elif not TutorialManager.is_active():
+		if save_phase == Phase.COMBAT:
+			save_phase = Phase.DICE_SELECT if current_run != null else Phase.FLEA_MARKET
+		elif save_phase == Phase.MAP and current_run == null:
+			save_phase = Phase.FLEA_MARKET
 
-	return {
+	var data := {
 		"save_version": SAVE_FORMAT_VERSION,
 		"app_version": get_app_version(),
 		"phase": Phase.keys()[save_phase],
@@ -276,6 +445,9 @@ func build_save_data() -> Dictionary:
 		"tutorial_step_id": TutorialManager.step_id,
 		"tutorial_state": TutorialManager.build_save_data(),
 	}
+	if current_run != null:
+		data["current_run"] = _serialize_run_state(current_run)
+	return data
 
 
 func apply_save_data(data: Dictionary) -> Phase:
@@ -286,6 +458,7 @@ func apply_save_data(data: Dictionary) -> Phase:
 
 
 func _apply_normalized_save_data(data: Dictionary) -> Phase:
+	clear_resolved_combat_result()
 	coins = int(data.get("coins", STARTING_COINS))
 	total_score = int(data.get("total_score", 0))
 	target_score = int(data.get("target_score", 150))
@@ -295,6 +468,8 @@ func _apply_normalized_save_data(data: Dictionary) -> Phase:
 	dice_bag = _deserialize_dice_bag(data.get("dice_bag", []))
 	modifiers = _deserialize_modifiers(data.get("modifiers", []))
 	selected_dice = _deserialize_selected_dice(data.get("selected_dice_indices", []))
+	current_run = _deserialize_run_state(data.get("current_run", {}))
+	last_run_result = {}
 	var tutorial_state: Dictionary = data.get("tutorial_state", {})
 	if tutorial_state.is_empty():
 		tutorial_state = {
@@ -396,6 +571,93 @@ func _serialize_dice_bag() -> Array:
 	for d in dice_bag.get_all():
 		dice_arr.append(_serialize_die(d))
 	return dice_arr
+
+
+func _serialize_run_state(run: RunState) -> Dictionary:
+	var node_arr: Array = []
+	var node_ids := run.nodes.keys()
+	node_ids.sort()
+	for id_key in node_ids:
+		var node: MapNodeRef = run.nodes[id_key]
+		var serialized_node := {
+			"id": node.id,
+			"type": MapNodeRef.NodeType.keys()[node.type],
+			"depth": node.depth,
+			"next_ids": node.next_ids.duplicate(),
+		}
+		node_arr.append(serialized_node)
+	return {
+		"seed": run.seed,
+		"current_node_id": run.current_node_id,
+		"visited_node_ids": run.visited_node_ids.duplicate(),
+		"completed_node_ids": run.completed_node_ids.duplicate(),
+		"shop_states": _serialize_shop_states(run.shop_states),
+		"nodes": node_arr,
+	}
+
+
+func _deserialize_run_state(raw: Variant) -> RunState:
+	if not (raw is Dictionary):
+		return null
+	var raw_dict: Dictionary = raw
+	var raw_nodes: Variant = raw_dict.get("nodes", [])
+	if not (raw_nodes is Array):
+		return null
+	var run := RunState.new()
+	run.seed = int(raw_dict.get("seed", 0))
+	run.current_node_id = int(raw_dict.get("current_node_id", -1))
+	run.visited_node_ids = _int_array_from_variant(raw_dict.get("visited_node_ids", []))
+	run.completed_node_ids = _int_array_from_variant(raw_dict.get("completed_node_ids", []))
+	run.shop_states = _deserialize_shop_states(raw_dict.get("shop_states", {}))
+	for raw_node in raw_nodes:
+		if not (raw_node is Dictionary):
+			continue
+		var node_dict: Dictionary = raw_node
+		var next_ids := _int_array_from_variant(node_dict.get("next_ids", []))
+		var node := MapNodeRef.new(
+			int(node_dict.get("id", -1)),
+			_map_node_type_from_save(str(node_dict.get("type", "COMBAT"))),
+			int(node_dict.get("depth", 0)),
+			next_ids
+		)
+		if node.id >= 0:
+			run.nodes[node.id] = node
+	if run.nodes.is_empty():
+		return null
+	return run
+
+
+func _serialize_shop_states(shop_states: Dictionary) -> Dictionary:
+	var result := {}
+	for node_id in shop_states.keys():
+		result[str(node_id)] = shop_states[node_id].duplicate(true)
+	return result
+
+
+func _deserialize_shop_states(raw: Variant) -> Dictionary:
+	var result := {}
+	if not (raw is Dictionary):
+		return result
+	var raw_dict: Dictionary = raw
+	for key in raw_dict.keys():
+		if raw_dict[key] is Dictionary:
+			result[int(key)] = raw_dict[key].duplicate(true)
+	return result
+
+
+func _int_array_from_variant(raw: Variant) -> Array[int]:
+	var result: Array[int] = []
+	if raw is Array:
+		for value in raw:
+			result.append(int(value))
+	return result
+
+
+func _map_node_type_from_save(raw_type: String) -> MapNodeRef.NodeType:
+	var type_idx := MapNodeRef.NodeType.keys().find(raw_type)
+	if type_idx < 0:
+		type_idx = MapNodeRef.NodeType.COMBAT
+	return type_idx as MapNodeRef.NodeType
 
 
 func _serialize_selected_dice_indices() -> Array:
@@ -502,6 +764,8 @@ func _deserialize_face(raw_face: Dictionary) -> DiceFace:
 
 
 func _phase_from_save_name(phase_name: String) -> Phase:
+	if phase_name == "MAP" and current_run == null:
+		return Phase.FLEA_MARKET
 	var phase_idx := Phase.keys().find(phase_name)
 	if phase_idx < 0:
 		phase_idx = Phase.FLEA_MARKET

--- a/scripts/map/map_generator.gd
+++ b/scripts/map/map_generator.gd
@@ -1,0 +1,149 @@
+class_name MapGenerator
+extends RefCounted
+
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+const RunStateRef := preload("res://scripts/map/run_state.gd")
+
+
+static func generate(p_seed: int, config: Dictionary) -> RunStateRef:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = p_seed
+
+	var depth: int = int(config["depth"])
+	var min_nodes: int = int(config["min_nodes_per_level"])
+	var max_nodes: int = int(config["max_nodes_per_level"])
+	var shop_probability: float = float(config["shop_probability"])
+	var max_consecutive_shops: int = int(config["max_consecutive_shops"])
+
+	var levels: Array = []
+	var next_id := 1
+	var previous_count := 0
+
+	for d in range(1, depth):
+		var count := _random_level_count(rng, min_nodes, max_nodes, previous_count)
+		var level: Array = []
+		for _i in range(count):
+			var node_type: int = MapNodeRef.NodeType.COMBAT
+			if rng.randf() < shop_probability:
+				node_type = MapNodeRef.NodeType.SHOP
+			level.append(MapNodeRef.new(next_id, node_type, d))
+			next_id += 1
+		levels.append(level)
+		previous_count = count
+
+	levels.append([MapNodeRef.new(next_id, MapNodeRef.NodeType.BOSS, depth)])
+
+	_connect_levels(levels, rng)
+	_enforce_max_consecutive_shops(levels, max_consecutive_shops)
+
+	var state := RunStateRef.new()
+	state.seed = p_seed
+	state.current_node_id = -1
+	for level in levels:
+		for node in level:
+			state.nodes[node.id] = node
+	return state
+
+
+static func _connect_levels(levels: Array, rng: RandomNumberGenerator) -> void:
+	for level_index in range(levels.size() - 1):
+		var top: Array = levels[level_index]
+		var bottom: Array = levels[level_index + 1]
+		var edge_indices: Array = []
+		for _i in range(top.size()):
+			edge_indices.append([])
+
+		for bottom_index in range(bottom.size()):
+			var top_index := _scaled_index(bottom_index, bottom.size(), top.size())
+			edge_indices[top_index].append(bottom_index)
+
+		for top_index in range(top.size()):
+			if edge_indices[top_index].is_empty():
+				edge_indices[top_index].append(_scaled_index(top_index, top.size(), bottom.size()))
+
+		for top_index in range(top.size()):
+			if edge_indices[top_index].size() >= 2:
+				continue
+			if rng.randf() >= 0.5:
+				continue
+			var primary: int = edge_indices[top_index][0]
+			var candidates: Array[int] = []
+			if primary > 0:
+				candidates.append(primary - 1)
+			if primary < bottom.size() - 1:
+				candidates.append(primary + 1)
+			var valid_candidates: Array[int] = []
+			for candidate in candidates:
+				if (
+					not edge_indices[top_index].has(candidate)
+					and _can_add_non_crossing_edge(edge_indices, top_index, candidate)
+				):
+					valid_candidates.append(candidate)
+			if valid_candidates.is_empty():
+				continue
+			var extra: int = valid_candidates[rng.randi_range(0, valid_candidates.size() - 1)]
+			if not edge_indices[top_index].has(extra):
+				edge_indices[top_index].append(extra)
+
+		for top_index in range(top.size()):
+			var node: MapNode = top[top_index]
+			var next_ids: Array[int] = []
+			for bottom_index in edge_indices[top_index]:
+				var child: MapNode = bottom[int(bottom_index)]
+				if not next_ids.has(child.id):
+					next_ids.append(child.id)
+			next_ids.sort()
+			node.next_ids = next_ids
+
+
+static func _random_level_count(rng: RandomNumberGenerator, min_nodes: int, max_nodes: int, previous_count: int) -> int:
+	var effective_max := max_nodes
+	if previous_count > 0:
+		effective_max = min(effective_max, previous_count * 2)
+	if effective_max < min_nodes:
+		return effective_max
+	return rng.randi_range(min_nodes, effective_max)
+
+
+static func _scaled_index(index: int, source_count: int, target_count: int) -> int:
+	if target_count <= 1 or source_count <= 1:
+		return 0
+	return int(round(float(index) * float(target_count - 1) / float(source_count - 1)))
+
+
+static func _can_add_non_crossing_edge(edge_indices: Array, top_index: int, bottom_index: int) -> bool:
+	for left_index in range(top_index):
+		for left_bottom_index in edge_indices[left_index]:
+			if int(left_bottom_index) > bottom_index:
+				return false
+	for right_index in range(top_index + 1, edge_indices.size()):
+		for right_bottom_index in edge_indices[right_index]:
+			if bottom_index > int(right_bottom_index):
+				return false
+	return true
+
+
+static func _enforce_max_consecutive_shops(levels: Array, max_shops: int) -> void:
+	var streaks := {}
+	for level_index in range(levels.size()):
+		var level: Array = levels[level_index]
+		for node in level:
+			var parent_streak := 0
+			if level_index > 0:
+				parent_streak = _max_parent_shop_streak(levels[level_index - 1], node.id, streaks)
+			if node.type == MapNodeRef.NodeType.SHOP and parent_streak >= max_shops:
+				node.type = MapNodeRef.NodeType.COMBAT
+				streaks[node.id] = 0
+			elif node.type == MapNodeRef.NodeType.SHOP:
+				streaks[node.id] = parent_streak + 1
+			else:
+				streaks[node.id] = 0
+
+
+static func _max_parent_shop_streak(parents: Array, node_id: int, streaks: Dictionary) -> int:
+	var result := 0
+	for parent in parents:
+		var parent_node: MapNode = parent
+		if parent_node.next_ids.has(node_id):
+			result = max(result, int(streaks.get(parent_node.id, 0)))
+	return result

--- a/scripts/map/map_generator.gd.uid
+++ b/scripts/map/map_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://b755gg8ghdej2

--- a/scripts/map/map_node.gd
+++ b/scripts/map/map_node.gd
@@ -1,5 +1,5 @@
-extends RefCounted
 class_name MapNode
+extends RefCounted
 
 enum NodeType { COMBAT, SHOP, BOSS }
 

--- a/scripts/map/map_node.gd
+++ b/scripts/map/map_node.gd
@@ -9,7 +9,9 @@ var depth: int = 0
 var next_ids: Array[int] = []
 
 
-func _init(p_id: int = -1, p_type: NodeType = NodeType.COMBAT, p_depth: int = 0, p_next_ids: Array[int] = [] as Array[int]) -> void:
+func _init(
+	p_id: int = -1, p_type: NodeType = NodeType.COMBAT, p_depth: int = 0, p_next_ids: Array[int] = [] as Array[int]
+) -> void:
 	id = p_id
 	type = p_type
 	depth = p_depth

--- a/scripts/map/map_node.gd
+++ b/scripts/map/map_node.gd
@@ -1,0 +1,16 @@
+extends RefCounted
+class_name MapNode
+
+enum NodeType { COMBAT, SHOP, BOSS }
+
+var id: int = -1
+var type: NodeType = NodeType.COMBAT
+var depth: int = 0
+var next_ids: Array[int] = []
+
+
+func _init(p_id: int = -1, p_type: NodeType = NodeType.COMBAT, p_depth: int = 0, p_next_ids: Array[int] = [] as Array[int]) -> void:
+	id = p_id
+	type = p_type
+	depth = p_depth
+	next_ids = p_next_ids.duplicate()

--- a/scripts/map/map_node.gd.uid
+++ b/scripts/map/map_node.gd.uid
@@ -1,0 +1,1 @@
+uid://dcl7cbgt223hn

--- a/scripts/map/run_state.gd
+++ b/scripts/map/run_state.gd
@@ -4,12 +4,47 @@ extends RefCounted
 var nodes: Dictionary = {}
 var current_node_id: int = -1
 var seed: int = 0
+var visited_node_ids: Array[int] = []
+var completed_node_ids: Array[int] = []
+var shop_states: Dictionary = {}
 
 
 func get_current_node() -> MapNode:
 	if current_node_id == -1:
 		return null
 	return nodes.get(current_node_id, null)
+
+
+func enter_node(node_id: int) -> void:
+	current_node_id = node_id
+	if not visited_node_ids.has(node_id):
+		visited_node_ids.append(node_id)
+
+
+func complete_current_node() -> void:
+	if current_node_id == -1:
+		return
+	if not completed_node_ids.has(current_node_id):
+		completed_node_ids.append(current_node_id)
+
+
+func has_visited(node_id: int) -> bool:
+	return visited_node_ids.has(node_id)
+
+
+func has_completed(node_id: int) -> bool:
+	return completed_node_ids.has(node_id)
+
+
+func set_shop_state(node_id: int, state: Dictionary) -> void:
+	shop_states[node_id] = state.duplicate(true)
+
+
+func get_shop_state(node_id: int) -> Dictionary:
+	if not shop_states.has(node_id):
+		return {}
+	var state: Dictionary = shop_states[node_id]
+	return state.duplicate(true)
 
 
 func available_node_ids() -> Array[int]:
@@ -19,6 +54,8 @@ func available_node_ids() -> Array[int]:
 			var node: MapNode = nodes[id_key]
 			if node.depth == 1:
 				result.append(node.id)
+		return result
+	if not has_completed(current_node_id):
 		return result
 	var current: MapNode = nodes.get(current_node_id, null)
 	if current == null:

--- a/scripts/map/run_state.gd
+++ b/scripts/map/run_state.gd
@@ -1,0 +1,30 @@
+class_name RunState
+extends RefCounted
+
+const MapNode := preload("res://scripts/map/map_node.gd")
+
+var nodes: Dictionary = {}  # int -> MapNode
+var current_node_id: int = -1  # -1 means no node entered yet
+var seed: int = 0
+
+
+func get_current_node() -> Variant:
+	if current_node_id == -1:
+		return null
+	return nodes.get(current_node_id, null)
+
+
+func available_node_ids() -> Array[int]:
+	var result: Array[int] = []
+	if current_node_id == -1:
+		for id_key in nodes.keys():
+			var node: MapNode = nodes[id_key]
+			if node.depth == 1:
+				result.append(node.id)
+		return result
+	var current: MapNode = nodes.get(current_node_id, null)
+	if current == null:
+		return result
+	for next_id in current.next_ids:
+		result.append(int(next_id))
+	return result

--- a/scripts/map/run_state.gd
+++ b/scripts/map/run_state.gd
@@ -1,14 +1,12 @@
 class_name RunState
 extends RefCounted
 
-const MapNode := preload("res://scripts/map/map_node.gd")
-
-var nodes: Dictionary = {}  # int -> MapNode
-var current_node_id: int = -1  # -1 means no node entered yet
+var nodes: Dictionary = {}
+var current_node_id: int = -1
 var seed: int = 0
 
 
-func get_current_node() -> Variant:
+func get_current_node() -> MapNode:
 	if current_node_id == -1:
 		return null
 	return nodes.get(current_node_id, null)

--- a/scripts/map/run_state.gd.uid
+++ b/scripts/map/run_state.gd.uid
@@ -1,0 +1,1 @@
+uid://ceq4v725hb72a

--- a/tests/integration/test_game_manager.gd
+++ b/tests/integration/test_game_manager.gd
@@ -10,6 +10,9 @@ var _temp_paths: Array[String] = []
 func before_each() -> void:
 	_manager = TestableGameManagerScript.new()
 	autoqfree(_manager)
+	var save_path := "user://gut_game_manager_%d.json" % Time.get_ticks_usec()
+	_manager.save_path = save_path
+	_temp_paths.append(save_path)
 	TutorialManager.completed = false
 	TutorialManager.clear_active_tutorial()
 
@@ -20,6 +23,40 @@ func after_each() -> void:
 	_temp_paths.clear()
 	TutorialManager.completed = false
 	TutorialManager.clear_active_tutorial()
+
+
+func _build_test_run_state() -> RunState:
+	var state := RunState.new()
+	state.nodes = {
+		1: MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2, 3] as Array[int]),
+		2: MapNode.new(2, MapNode.NodeType.COMBAT, 2, [4] as Array[int]),
+		3: MapNode.new(3, MapNode.NodeType.SHOP, 2, [4] as Array[int]),
+		4: MapNode.new(4, MapNode.NodeType.BOSS, 3, [] as Array[int]),
+	}
+	state.current_node_id = -1
+	state.seed = 42
+	return state
+
+
+func test_phase_map_exists() -> void:
+	assert_true(GameManager.Phase.keys().has("MAP"))
+
+
+func test_initial_run_state_is_null() -> void:
+	assert_null(_manager.current_run)
+	assert_eq_deep(_manager.last_run_result, {})
+
+
+func test_start_game_creates_run() -> void:
+	_manager.last_run_result = {"victory": true}
+
+	await _manager.start_game(true)
+
+	assert_not_null(_manager.current_run)
+	assert_eq(_manager.current_run.current_node_id, -1)
+	assert_true(_manager.current_run.nodes.size() >= 2)
+	assert_eq_deep(_manager.last_run_result, {})
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
 
 
 func test_buy_item_adds_die_from_catalogue_entry() -> void:
@@ -95,6 +132,388 @@ func test_advance_round_updates_reward_target_and_phase() -> void:
 	assert_eq_deep(_manager.phase_history, [_manager.Phase.FLEA_MARKET])
 
 
+func test_advance_round_outside_run_goes_to_flea_market() -> void:
+	_manager.current_run = null
+	_manager.last_run_result = {}
+	_manager.current_round = 1
+
+	_manager.advance_round()
+
+	assert_eq(_manager.current_phase, _manager.Phase.FLEA_MARKET)
+	assert_eq(_manager.current_round, 2)
+
+
+func test_end_combat_in_run_victory_routes_through_complete_current_node() -> void:
+	await _manager.start_game(true)
+	_manager.current_run.enter_node(1)
+	var final_score: int = _manager.target_score
+
+	_manager.end_combat(final_score, true)
+
+	assert_eq(_manager.total_score, final_score)
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+
+
+func test_end_combat_completed_tutorial_run_start_goes_to_map() -> void:
+	_manager.current_phase = _manager.Phase.COMBAT
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = -1
+	TutorialManager.completed = true
+	TutorialManager.clear_active_tutorial()
+
+	_manager.end_combat(_manager.target_score, true)
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_not_null(_manager.current_run)
+	assert_eq(_manager.current_run.current_node_id, -1)
+	assert_eq_deep(_manager.current_run.completed_node_ids, [] as Array[int])
+
+
+func test_end_combat_first_run_intro_win_uses_tutorial_continuation() -> void:
+	await _manager.start_game(false)
+	var intro_target: int = _manager.target_score
+
+	assert_not_null(_manager.current_run)
+	assert_eq(_manager.current_phase, _manager.Phase.COMBAT)
+	assert_eq(_manager.current_round, 0)
+	assert_true(TutorialManager.report_action("advance_intro"))
+	assert_true(TutorialManager.report_action("combat_roll", {"roll_number": 0}))
+	assert_true(TutorialManager.report_action("hold_changed", {"held_indices": [0]}))
+	assert_true(TutorialManager.report_action("combat_roll", {"roll_number": 1}))
+	assert_true(TutorialManager.report_action("advance_intro"))
+	assert_true(TutorialManager.report_action("combat_score"))
+	assert_eq(TutorialManager.step_id, TutorialManager.STEP_INTRO_WIN)
+	assert_true(TutorialManager.report_action("combat_next_round"))
+
+	_manager.end_combat(intro_target, true)
+
+	assert_eq(_manager.total_score, intro_target)
+	assert_eq(_manager.current_phase, _manager.Phase.FLEA_MARKET)
+	assert_ne(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq(_manager.current_round, 1)
+	assert_eq(_manager.target_score, _manager.BASE_TARGET)
+	assert_eq(_manager.coins, 35)
+	assert_not_null(_manager.current_run)
+	assert_eq_deep(_manager.last_run_result, {})
+
+
+func test_end_combat_in_run_defeat_calls_end_run() -> void:
+	await _manager.start_game(true)
+	_manager.current_round = 2
+	_manager.coins = 17
+
+	_manager.end_combat(0, false)
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAIN_MENU)
+	assert_null(_manager.current_run)
+	assert_eq(_manager.total_score, 0)
+	assert_eq_deep(
+		_manager.last_run_result,
+		{
+			"victory": false,
+			"round": 2,
+			"total_score": 0,
+			"coins": 17,
+		}
+	)
+
+
+func test_end_combat_outside_run_uses_legacy_advance_or_main_menu() -> void:
+	_manager.current_run = null
+	_manager.last_run_result = {}
+	_manager.current_round = 1
+
+	_manager.end_combat(_manager.target_score, true)
+
+	assert_eq(_manager.current_phase, _manager.Phase.FLEA_MARKET)
+	assert_eq(_manager.current_round, 2)
+
+
+func test_end_combat_outside_run_defeat_goes_to_main_menu() -> void:
+	_manager.current_run = null
+	_manager.last_run_result = {}
+	_manager.current_phase = _manager.Phase.COMBAT
+
+	_manager.end_combat(0, false)
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAIN_MENU)
+	assert_null(_manager.current_run)
+	assert_eq_deep(_manager.last_run_result, {})
+
+
+func test_complete_current_node_without_current_node_warns_and_does_not_advance() -> void:
+	await _manager.start_game(true)
+	_manager.current_round = 1
+
+	_manager.complete_current_node()
+
+	assert_engine_error("Cannot complete a map node before one is selected")
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq(_manager.current_round, 1)
+
+
+func test_complete_current_node_outside_run_warns_and_returns() -> void:
+	_manager.current_run = null
+	_manager.current_phase = _manager.Phase.FLEA_MARKET
+	_manager.current_round = 2
+
+	_manager.complete_current_node()
+
+	assert_engine_error("Cannot complete a map node without an active run")
+	assert_eq(_manager.current_phase, _manager.Phase.FLEA_MARKET)
+	assert_eq(_manager.current_round, 2)
+	assert_eq_deep(_manager.phase_history, [])
+
+
+func test_complete_current_node_combat_advances_round_and_goes_to_map() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = 1
+	_manager.current_round = 2
+	_manager.coins = 10
+	_manager.target_score = 200
+	var selected_dice: Array[Die] = [TestData.die_from_values([1, 2, 3, 4, 5, 6])]
+	_manager.selected_dice = selected_dice
+
+	_manager.complete_current_node()
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq(_manager.current_round, 3)
+	assert_eq(_manager.coins, 30)
+	assert_eq(_manager.target_score, 337)
+	assert_eq(_manager.selected_dice.size(), 0)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
+
+
+func test_complete_current_node_shop_goes_to_map_without_round_advance() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = 3
+	_manager.current_round = 2
+	_manager.coins = 10
+	_manager.target_score = 200
+	var selected_dice: Array[Die] = [TestData.die_from_values([1, 2, 3, 4, 5, 6])]
+	_manager.selected_dice = selected_dice
+
+	_manager.complete_current_node()
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq(_manager.current_round, 2)
+	assert_eq(_manager.coins, 10)
+	assert_eq(_manager.target_score, 200)
+	assert_eq(_manager.selected_dice.size(), 1)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
+
+
+func test_complete_current_node_boss_ends_run_with_victory_without_next_round() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = 4
+	_manager.current_round = 3
+	_manager.coins = 10
+	_manager.target_score = 200
+	_manager.total_score = 640
+
+	_manager.complete_current_node()
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAIN_MENU)
+	assert_null(_manager.current_run)
+	assert_eq_deep(
+		_manager.last_run_result,
+		{
+			"victory": true,
+			"round": 3,
+			"total_score": 640,
+			"coins": 35,
+		}
+	)
+	assert_eq(_manager.target_score, 200)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAIN_MENU])
+
+
+func test_flea_market_continue_outside_run_goes_to_dice_select() -> void:
+	_manager.current_run = null
+	_manager.current_phase = _manager.Phase.FLEA_MARKET
+
+	_manager.flea_market_continue()
+
+	assert_eq(_manager.current_phase, _manager.Phase.DICE_SELECT)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.DICE_SELECT])
+
+
+func test_flea_market_continue_onboarding_run_start_goes_to_dice_select() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = -1
+	_manager.current_phase = _manager.Phase.FLEA_MARKET
+
+	_manager.flea_market_continue()
+
+	assert_engine_error("Unexpected Flea Market continue before selecting a map node")
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
+
+
+func test_flea_market_continue_shop_node_completes_to_map() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = 3
+	_manager.current_phase = _manager.Phase.FLEA_MARKET
+	_manager.current_round = 2
+	_manager.coins = 10
+	_manager.target_score = 200
+
+	_manager.flea_market_continue()
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq(_manager.current_round, 2)
+	assert_eq(_manager.coins, 10)
+	assert_eq(_manager.target_score, 200)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
+
+
+func test_flea_market_continue_combat_node_warns_and_goes_to_map() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = 1
+	_manager.current_phase = _manager.Phase.FLEA_MARKET
+	_manager.current_round = 2
+
+	_manager.flea_market_continue()
+
+	assert_engine_error("Unexpected Flea Market continue from non-shop map node")
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq(_manager.current_round, 2)
+	assert_not_null(_manager.current_run)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
+
+
+func test_flea_market_continue_boss_node_warns_and_goes_to_map() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = 4
+	_manager.current_phase = _manager.Phase.FLEA_MARKET
+	_manager.current_round = 3
+
+	_manager.flea_market_continue()
+
+	assert_engine_error("Unexpected Flea Market continue from non-shop map node")
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq(_manager.current_round, 3)
+	assert_not_null(_manager.current_run)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
+
+
+func test_end_run_victory_returns_to_main_menu_with_result() -> void:
+	await _manager.start_game(true)
+	_manager.current_round = 4
+	_manager.total_score = 512
+	_manager.coins = 37
+	_manager.save_game()
+	assert_true(_manager.has_save())
+
+	_manager.end_run(true)
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAIN_MENU)
+	assert_null(_manager.current_run)
+	assert_false(_manager.has_save())
+	assert_false(_manager.can_load_save())
+	assert_eq_deep(
+		_manager.last_run_result,
+		{
+			"victory": true,
+			"round": 4,
+			"total_score": 512,
+			"coins": 37,
+		}
+	)
+
+
+func test_end_run_defeat_returns_to_main_menu_with_result() -> void:
+	await _manager.start_game(true)
+	_manager.current_round = 4
+	_manager.total_score = 512
+	_manager.coins = 37
+	_manager.save_game()
+	assert_true(_manager.has_save())
+
+	_manager.end_run(false)
+
+	assert_eq(_manager.current_phase, _manager.Phase.MAIN_MENU)
+	assert_null(_manager.current_run)
+	assert_false(_manager.has_save())
+	assert_false(_manager.can_load_save())
+	assert_eq_deep(
+		_manager.last_run_result,
+		{
+			"victory": false,
+			"round": 4,
+			"total_score": 512,
+			"coins": 37,
+		}
+	)
+
+
+func test_abandon_run_clears_run_without_result() -> void:
+	await _manager.start_game(true)
+
+	_manager.abandon_run()
+
+	assert_null(_manager.current_run)
+	assert_eq_deep(_manager.last_run_result, {})
+
+
+func test_enter_map_node_rejects_unavailable_node() -> void:
+	_manager.current_run = _build_test_run_state()
+
+	_manager.enter_map_node(99)
+
+	assert_engine_error("Cannot enter unavailable map node")
+	assert_eq(_manager.current_run.current_node_id, -1)
+	assert_eq_deep(_manager.phase_history, [])
+
+
+func test_enter_map_node_outside_run_warns_and_returns() -> void:
+	_manager.current_run = null
+	_manager.current_phase = _manager.Phase.MAP
+
+	_manager.enter_map_node(1)
+
+	assert_engine_error("Cannot enter a map node without an active run")
+	assert_eq(_manager.current_phase, _manager.Phase.MAP)
+	assert_eq_deep(_manager.phase_history, [])
+
+
+func test_enter_map_node_combat_sets_current_node_and_goes_to_dice_select() -> void:
+	_manager.current_run = _build_test_run_state()
+
+	_manager.enter_map_node(1)
+
+	assert_eq(_manager.current_run.current_node_id, 1)
+	assert_eq(_manager.current_run.visited_node_ids, [1] as Array[int])
+	assert_eq(_manager.current_phase, _manager.Phase.DICE_SELECT)
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.DICE_SELECT])
+
+
+func test_enter_map_node_shop_goes_to_flea_market() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_run.complete_current_node()
+
+	_manager.enter_map_node(3)
+
+	assert_eq(_manager.current_run.current_node_id, 3)
+	assert_eq(_manager.current_phase, _manager.Phase.FLEA_MARKET)
+
+
+func test_enter_map_node_boss_scales_target_and_goes_to_dice_select() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_run.complete_current_node()
+	_manager.current_run.enter_node(2)
+	_manager.current_run.complete_current_node()
+	_manager.target_score = 200
+
+	_manager.enter_map_node(4)
+
+	assert_eq(_manager.current_run.current_node_id, 4)
+	assert_eq(_manager.target_score, 300)
+	assert_eq(_manager.current_phase, _manager.Phase.DICE_SELECT)
+
+
 func test_build_save_data_normalizes_combat_phase() -> void:
 	_manager.current_phase = _manager.Phase.COMBAT
 
@@ -114,11 +533,55 @@ func test_build_save_data_keeps_combat_phase_for_active_tutorial_checkpoint() ->
 	assert_eq(data["tutorial_mode"], TutorialManager.MODE_FIRST_RUN)
 
 
+func test_build_save_data_normalizes_map_run_combat_to_dice_select() -> void:
+	_manager.current_phase = _manager.Phase.COMBAT
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+
+	var data: Dictionary = _manager.build_save_data()
+
+	assert_eq(data["phase"], "DICE_SELECT")
+	assert_true(data.has("current_run"))
+
+
 func test_build_save_data_includes_version_metadata() -> void:
 	var data: Dictionary = _manager.build_save_data()
 
 	assert_eq(data["save_version"], 2)
 	assert_eq(data["app_version"], _manager.get_app_version())
+
+
+func test_build_save_data_serializes_current_run_without_last_result() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_run.complete_current_node()
+	(
+		_manager
+		. current_run
+		. set_shop_state(
+			3,
+			{
+				"offerings": [{"id": "loaded_die"}],
+				"sold": [true],
+				"reroll_count": 1,
+			}
+		)
+	)
+	_manager.last_run_result = {"victory": true}
+
+	var data: Dictionary = _manager.build_save_data()
+	var run_data: Dictionary = data.get("current_run", {})
+
+	assert_true(data.has("current_run"))
+	assert_eq(run_data.get("seed"), 42)
+	assert_eq(run_data.get("current_node_id"), 1)
+	assert_eq(run_data.get("visited_node_ids"), [1])
+	assert_eq(run_data.get("completed_node_ids"), [1])
+	assert_eq(run_data.get("shop_states", {})["3"]["offerings"][0]["id"], "loaded_die")
+	assert_eq(run_data.get("shop_states", {})["3"]["sold"], [true])
+	assert_eq(run_data.get("shop_states", {})["3"]["reroll_count"], 1)
+	assert_eq((run_data.get("nodes", []) as Array).size(), 4)
+	assert_false(data.has("last_run_result"))
 
 
 func test_build_and_apply_save_data_round_trip_preserves_state() -> void:
@@ -159,6 +622,22 @@ func test_build_and_apply_save_data_round_trip_preserves_state() -> void:
 	_manager.modifiers[0].rarity = "rare"
 	var selected: Array[Die] = [_manager.dice_bag.get_die(0)]
 	_manager.selected_dice = selected
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_run.complete_current_node()
+	_manager.current_run.enter_node(3)
+	(
+		_manager
+		. current_run
+		. set_shop_state(
+			3,
+			{
+				"offerings": [{"id": "loaded_die"}],
+				"sold": [false],
+				"reroll_count": 0,
+			}
+		)
+	)
 	TutorialManager.start_replay()
 	TutorialManager.enter_scene(TutorialManager.SCENE_DICE_SELECT)
 	TutorialManager.report_action("advance_intro")
@@ -189,9 +668,29 @@ func test_build_and_apply_save_data_round_trip_preserves_state() -> void:
 	assert_eq(restored.dice_bag.get_die(0).get_face(1).id, "pip_6")
 	assert_eq(restored.dice_bag.get_die(0).get_face(2).face_type, DiceFace.Type.MULT)
 	assert_eq(restored.modifiers[0].rarity, "rare")
+	assert_not_null(restored.current_run)
+	assert_eq(restored.current_run.seed, 42)
+	assert_eq(restored.current_run.current_node_id, 3)
+	assert_eq(restored.current_run.visited_node_ids, [1, 3] as Array[int])
+	assert_eq(restored.current_run.completed_node_ids, [1] as Array[int])
+	assert_eq(restored.current_run.nodes.size(), 4)
+	assert_eq(restored.current_run.nodes[3].type, MapNode.NodeType.SHOP)
+	assert_eq(restored.current_run.get_shop_state(3)["offerings"][0]["id"], "loaded_die")
+	assert_eq(restored.current_run.available_node_ids().size(), 0)
 	assert_eq(TutorialManager.mode, TutorialManager.MODE_REPLAY)
 	assert_eq(TutorialManager.checkpoint_scene, TutorialManager.SCENE_DICE_SELECT)
 	assert_eq_deep(restored.build_save_data(), data)
+
+
+func test_loading_save_clears_run_state() -> void:
+	var data: Dictionary = _manager.build_save_data()
+	_manager.current_run = _build_test_run_state()
+	_manager.last_run_result = {"victory": true}
+
+	_manager.apply_save_data(data)
+
+	assert_null(_manager.current_run)
+	assert_eq_deep(_manager.last_run_result, {})
 
 
 func test_start_tutorial_replay_resets_run_and_enters_intro_combat() -> void:
@@ -201,6 +700,8 @@ func test_start_tutorial_replay_resets_run_and_enters_intro_combat() -> void:
 	_manager.modifiers = (
 		[TestData.modifier("x_mult", 3.0, "yahtzee", "yahtzee_hunter", "Yahtzee Hunter")] as Array[Modifier]
 	)
+	_manager.current_run = RunState.new()
+	_manager.last_run_result = {"victory": true}
 
 	await _manager.start_tutorial_replay()
 
@@ -212,10 +713,12 @@ func test_start_tutorial_replay_resets_run_and_enters_intro_combat() -> void:
 	assert_eq(TutorialManager.mode, TutorialManager.MODE_REPLAY)
 	assert_eq(TutorialManager.step_id, TutorialManager.STEP_INTRO_WELCOME)
 	assert_eq_deep(TutorialManager.required_combat_hold_indices, [0])
+	assert_null(_manager.current_run)
+	assert_eq_deep(_manager.last_run_result, {})
 	assert_eq_deep(_manager.phase_history, [_manager.Phase.COMBAT])
 
 
-func test_skip_active_tutorial_completes_and_enters_normal_market_run() -> void:
+func test_skip_active_tutorial_completes_and_keeps_map_run() -> void:
 	_manager.current_phase = _manager.Phase.COMBAT
 	_manager.coins = 25
 	_manager.current_round = 0
@@ -223,6 +726,8 @@ func test_skip_active_tutorial_completes_and_enters_normal_market_run() -> void:
 	_manager.modifiers = ([TestData.modifier("x_mult", 3.0, "yahtzee")] as Array[Modifier])
 	var selected_dice: Array[Die] = [TestData.die_from_values([6, 6, 6, 6, 6])]
 	_manager.selected_dice = selected_dice
+	_manager.current_run = RunState.new()
+	_manager.last_run_result = {"victory": true}
 	TutorialManager.start_first_run()
 
 	_manager.skip_active_tutorial()
@@ -235,7 +740,12 @@ func test_skip_active_tutorial_completes_and_enters_normal_market_run() -> void:
 	assert_eq(_manager.modifiers.size(), 0)
 	assert_eq(_manager.dice_bag.size(), 5)
 	assert_eq(_manager.selected_dice.size(), 0)
-	assert_eq_deep(_manager.phase_history, [_manager.Phase.FLEA_MARKET])
+	assert_not_null(_manager.current_run)
+	if _manager.current_run != null:
+		assert_eq(_manager.current_run.current_node_id, -1)
+		assert_true(_manager.current_run.nodes.size() >= 2)
+	assert_eq_deep(_manager.last_run_result, {})
+	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
 
 
 func test_apply_save_data_migrates_legacy_save_without_version() -> void:
@@ -260,6 +770,31 @@ func test_apply_save_data_migrates_legacy_save_without_version() -> void:
 	assert_eq(_manager.dice_bag.size(), 1)
 	assert_eq(_manager.dice_bag.get_die(0).die_name, "Legacy Die")
 	assert_eq(_manager.build_save_data()["save_version"], GameManager.SAVE_FORMAT_VERSION)
+
+
+func test_apply_save_data_loads_map_save_at_flea_market_without_run_state() -> void:
+	var map_save := {
+		"save_version": GameManager.SAVE_FORMAT_VERSION,
+		"app_version": _manager.get_app_version(),
+		"phase": "MAP",
+		"coins": 41,
+		"total_score": 240,
+		"target_score": 300,
+		"hands_per_round": 5,
+		"rerolls_per_hand": 2,
+		"current_round": 4,
+		"dice_bag": [],
+		"selected_dice_indices": [],
+		"modifiers": [],
+	}
+	_manager.current_run = RunState.new()
+	_manager.last_run_result = {"won": true}
+
+	var restored_phase: int = _manager.apply_save_data(map_save)
+
+	assert_eq(restored_phase, _manager.Phase.FLEA_MARKET)
+	assert_null(_manager.current_run)
+	assert_eq_deep(_manager.last_run_result, {})
 
 
 func test_apply_save_data_rejects_future_save_version_without_mutating_state() -> void:

--- a/tests/integration/test_run_flow.gd
+++ b/tests/integration/test_run_flow.gd
@@ -1,0 +1,450 @@
+extends GutTest
+
+const FLEA_MARKET_SCENE := preload("res://scenes/flea_market/flea_market_screen.tscn")
+const COMBAT_SCREEN_SCENE := preload("res://scenes/combat/combat_screen.tscn")
+const DICE_SELECT_SCENE := preload("res://scenes/dice_select/dice_select_screen.tscn")
+const MAP_SCREEN_SCENE := preload("res://scenes/map/map_screen.tscn")
+
+var _original_current_run: RunState
+var _original_current_phase: int
+var _original_coins: int
+var _original_total_score: int
+var _original_target_score: int
+var _original_hands_per_round: int
+var _original_rerolls_per_hand: int
+var _original_current_round: int
+var _original_dice_bag: DiceBag
+var _original_modifiers: Array[Modifier]
+var _original_selected_dice: Array[Die]
+var _original_last_run_result: Dictionary
+var _original_save_path: String
+var _original_tutorial_state: Dictionary
+var _temp_paths: Array[String] = []
+
+
+func before_each() -> void:
+	_original_current_run = GameManager.current_run
+	_original_current_phase = GameManager.current_phase
+	_original_coins = GameManager.coins
+	_original_total_score = GameManager.total_score
+	_original_target_score = GameManager.target_score
+	_original_hands_per_round = GameManager.hands_per_round
+	_original_rerolls_per_hand = GameManager.rerolls_per_hand
+	_original_current_round = GameManager.current_round
+	_original_dice_bag = GameManager.dice_bag
+	_original_modifiers.assign(GameManager.modifiers)
+	_original_selected_dice.assign(GameManager.selected_dice)
+	_original_last_run_result = GameManager.last_run_result.duplicate(true)
+	_original_save_path = GameManager.save_path
+	_original_tutorial_state = TutorialManager.build_save_data().duplicate(true)
+	var save_path := "user://gut_run_flow_%d.json" % Time.get_ticks_usec()
+	GameManager.save_path = save_path
+	_temp_paths.append(save_path)
+	GameManager.current_run = null
+	GameManager.current_phase = GameManager.Phase.FLEA_MARKET
+	GameManager.coins = 50
+	GameManager.total_score = 0
+	GameManager.target_score = GameManager.BASE_TARGET
+	GameManager.hands_per_round = 4
+	GameManager.rerolls_per_hand = 3
+	GameManager.current_round = 1
+	GameManager.dice_bag = DiceBag.new()
+	for _i in range(5):
+		GameManager.dice_bag.add_die(Die.new())
+	GameManager.modifiers.clear()
+	GameManager.selected_dice.clear()
+	GameManager.last_run_result = {}
+	GameManager.clear_resolved_combat_result()
+	_apply_inactive_tutorial_state()
+
+
+func after_each() -> void:
+	GameManager.current_run = _original_current_run
+	GameManager.current_phase = _original_current_phase
+	GameManager.coins = _original_coins
+	GameManager.total_score = _original_total_score
+	GameManager.target_score = _original_target_score
+	GameManager.hands_per_round = _original_hands_per_round
+	GameManager.rerolls_per_hand = _original_rerolls_per_hand
+	GameManager.current_round = _original_current_round
+	GameManager.dice_bag = _original_dice_bag
+	GameManager.modifiers.assign(_original_modifiers)
+	GameManager.selected_dice.assign(_original_selected_dice)
+	GameManager.last_run_result = _original_last_run_result
+	GameManager.save_path = _original_save_path
+	GameManager.clear_resolved_combat_result()
+	get_tree().paused = false
+	for path in _temp_paths:
+		GameManager.delete_save(path)
+	_temp_paths.clear()
+	TutorialManager.apply_save_data(_original_tutorial_state)
+
+
+func _apply_inactive_tutorial_state() -> void:
+	(
+		TutorialManager
+		. apply_save_data(
+			{
+				"mode": TutorialManager.MODE_INACTIVE,
+				"step_id": "",
+				"completed": true,
+				"checkpoint_scene": "",
+				"loaded_die_index": -1,
+				"improved_die_index": -1,
+				"selected_bag_indices": [],
+				"required_combat_hold_indices": [],
+			}
+		)
+	)
+
+
+func _build_test_run_state(current_node_id: int) -> RunState:
+	var state := RunState.new()
+	state.nodes = {
+		1: MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2, 3] as Array[int]),
+		2: MapNode.new(2, MapNode.NodeType.COMBAT, 2, [4] as Array[int]),
+		3: MapNode.new(3, MapNode.NodeType.SHOP, 2, [4] as Array[int]),
+		4: MapNode.new(4, MapNode.NodeType.BOSS, 3, [] as Array[int]),
+	}
+	state.current_node_id = current_node_id
+	return state
+
+
+func _build_boss_start_run_state() -> RunState:
+	var state := RunState.new()
+	state.nodes = {1: MapNode.new(1, MapNode.NodeType.BOSS, 1, [] as Array[int])}
+	state.current_node_id = -1
+	return state
+
+
+func _add_flea_market_screen():
+	var flea_market = FLEA_MARKET_SCENE.instantiate()
+	autoqfree(flea_market)
+	add_child_autofree(flea_market)
+	await wait_process_frames(2)
+	return flea_market
+
+
+func _add_combat_screen():
+	var combat_screen = COMBAT_SCREEN_SCENE.instantiate()
+	autoqfree(combat_screen)
+	add_child_autofree(combat_screen)
+	await wait_process_frames(2)
+	return combat_screen
+
+
+func _add_dice_select_screen():
+	var dice_select = DICE_SELECT_SCENE.instantiate()
+	autoqfree(dice_select)
+	add_child_autofree(dice_select)
+	await wait_process_frames(2)
+	return dice_select
+
+
+func _add_map_screen():
+	var map_screen = MAP_SCREEN_SCENE.instantiate()
+	autoqfree(map_screen)
+	add_child_autofree(map_screen)
+	await wait_process_frames(2)
+	return map_screen
+
+
+func _press_ready_button(flea_market) -> void:
+	flea_market._ready_btn.emit_signal("pressed")
+	await wait_process_frames(2)
+
+
+func _press_menu_button(screen: Node) -> void:
+	var menu_btn = _find_button_with_text(screen, "MENU")
+	assert_not_null(menu_btn)
+	if menu_btn != null:
+		menu_btn.emit_signal("pressed")
+	await wait_process_frames(2)
+
+
+func _offering_ids(flea_market) -> Array[String]:
+	var ids: Array[String] = []
+	for item in flea_market._shop_offerings:
+		ids.append(str(item.get("id", "")))
+	return ids
+
+
+func _first_direct_buy_index(flea_market) -> int:
+	for i in range(flea_market._shop_offerings.size()):
+		if str(flea_market._shop_offerings[i].get("category", "")) != "face":
+			return i
+	return -1
+
+
+func _find_button_with_text(root: Node, text: String):
+	for child in root.find_children("*", "Button", true, false):
+		if child is Button and child.text == text:
+			return child
+	return null
+
+
+func _read_current_save_data() -> Dictionary:
+	var file := FileAccess.open(GameManager.save_path, FileAccess.READ)
+	assert_not_null(file)
+	if file == null:
+		return {}
+	var parsed: Variant = JSON.parse_string(file.get_as_text())
+	if parsed is Dictionary:
+		return parsed
+	return {}
+
+
+func _apply_tutorial_step(step_id: String) -> void:
+	(
+		TutorialManager
+		. apply_save_data(
+			{
+				"mode": TutorialManager.MODE_FIRST_RUN,
+				"step_id": step_id,
+				"completed": false,
+				"checkpoint_scene": TutorialManager.SCENE_FLEA_MARKET,
+				"loaded_die_index": 5,
+				"improved_die_index": 0,
+				"selected_bag_indices": [],
+				"required_combat_hold_indices": [],
+			}
+		)
+	)
+
+
+func test_flea_market_ready_button_says_continue_on_shop_run_node() -> void:
+	GameManager.current_run = _build_test_run_state(3)
+
+	var flea_market = await _add_flea_market_screen()
+
+	assert_eq(flea_market._ready_btn.text, "CONTINUE")
+
+
+func test_flea_market_ready_button_says_ready_outside_run() -> void:
+	GameManager.current_run = null
+
+	var flea_market = await _add_flea_market_screen()
+
+	assert_eq(flea_market._ready_btn.text, "READY!")
+
+
+func test_flea_market_ready_button_says_ready_at_run_start() -> void:
+	GameManager.current_run = _build_test_run_state(-1)
+
+	var flea_market = await _add_flea_market_screen()
+
+	assert_eq(flea_market._ready_btn.text, "READY!")
+
+
+func test_flea_market_ready_button_press_outside_run_goes_to_dice_select() -> void:
+	GameManager.current_run = null
+
+	var flea_market = await _add_flea_market_screen()
+	await _press_ready_button(flea_market)
+
+	assert_eq(GameManager.current_phase, GameManager.Phase.DICE_SELECT)
+
+
+func test_flea_market_ready_button_press_on_shop_run_node_goes_to_map() -> void:
+	GameManager.current_run = _build_test_run_state(3)
+
+	var flea_market = await _add_flea_market_screen()
+	assert_eq(flea_market._ready_btn.text, "CONTINUE")
+	await _press_ready_button(flea_market)
+
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAP)
+
+
+func test_flea_market_map_shop_state_survives_scene_reload_purchase_and_reroll() -> void:
+	GameManager.current_run = _build_test_run_state(3)
+	GameManager.current_run.seed = 123
+	GameManager.current_phase = GameManager.Phase.FLEA_MARKET
+	GameManager.coins = 200
+
+	var first_market = await _add_flea_market_screen()
+	var first_ids := _offering_ids(first_market)
+	var buy_index := _first_direct_buy_index(first_market)
+	assert_gte(buy_index, 0)
+	first_market._on_shop_item_buy(buy_index)
+	await wait_process_frames(1)
+	assert_true(first_market._sold[buy_index])
+	assert_true(GameManager.has_save())
+
+	var after_buy_market = await _add_flea_market_screen()
+	assert_eq(_offering_ids(after_buy_market), first_ids)
+	assert_true(after_buy_market._sold[buy_index])
+	after_buy_market._on_reroll_pressed()
+	await wait_process_frames(1)
+	var rerolled_ids := _offering_ids(after_buy_market)
+	assert_eq(GameManager.current_run.get_shop_state(3).get("reroll_count", -1), 1)
+
+	var restored_market = await _add_flea_market_screen()
+	assert_eq(_offering_ids(restored_market), rerolled_ids)
+	assert_eq(restored_market._sold, [false, false, false, false, false])
+
+
+func test_flea_market_menu_button_abandons_active_run_without_result() -> void:
+	GameManager.current_run = _build_test_run_state(3)
+	GameManager.current_phase = GameManager.Phase.FLEA_MARKET
+	GameManager.last_run_result = {}
+	GameManager.save_game()
+	assert_true(GameManager.can_load_save())
+
+	var flea_market = await _add_flea_market_screen()
+	await _press_menu_button(flea_market)
+
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAIN_MENU)
+	assert_eq_deep(GameManager.last_run_result, {})
+	assert_false(GameManager.has_save())
+	assert_false(GameManager.can_load_save())
+
+
+func test_flea_market_ready_button_reports_tutorial_go_to_dice_select() -> void:
+	_apply_tutorial_step(TutorialManager.STEP_GO_TO_DICE_SELECT)
+
+	var flea_market = await _add_flea_market_screen()
+	await _press_ready_button(flea_market)
+
+	assert_eq(TutorialManager.step_id, TutorialManager.STEP_SELECT_REQUIRED_DICE)
+	assert_eq(GameManager.current_phase, GameManager.Phase.DICE_SELECT)
+
+
+func test_flea_market_ready_button_during_first_run_keeps_tutorial_on_dice_select() -> void:
+	_apply_tutorial_step(TutorialManager.STEP_GO_TO_DICE_SELECT)
+	GameManager.current_run = _build_test_run_state(-1)
+	GameManager.current_phase = GameManager.Phase.FLEA_MARKET
+
+	var flea_market = await _add_flea_market_screen()
+	await _press_ready_button(flea_market)
+
+	assert_eq(TutorialManager.step_id, TutorialManager.STEP_SELECT_REQUIRED_DICE)
+	assert_eq(GameManager.current_phase, GameManager.Phase.DICE_SELECT)
+	assert_not_null(GameManager.current_run)
+	assert_eq(GameManager.current_run.current_node_id, -1)
+
+
+func test_combat_pause_quit_abandons_active_run_without_defeat_result() -> void:
+	GameManager.current_run = _build_test_run_state(1)
+	GameManager.current_phase = GameManager.Phase.COMBAT
+	GameManager.last_run_result = {}
+	GameManager.save_game()
+	assert_true(GameManager.can_load_save())
+
+	var combat_screen = await _add_combat_screen()
+	combat_screen.combat_mgr.running_score = 42
+	combat_screen._pause_overlay.visible = true
+	get_tree().paused = true
+	combat_screen._on_pause_quit_pressed()
+	await wait_seconds(0.45)
+
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAIN_MENU)
+	assert_eq_deep(GameManager.last_run_result, {})
+	assert_false(GameManager.has_save())
+	assert_false(GameManager.can_load_save())
+
+
+func test_combat_victory_result_overlay_saves_resolved_map_state() -> void:
+	GameManager.current_run = _build_test_run_state(1)
+	GameManager.current_phase = GameManager.Phase.COMBAT
+	GameManager.current_round = 1
+	GameManager.coins = 50
+	GameManager.save_game()
+	assert_true(GameManager.can_load_save())
+
+	var combat_screen = await _add_combat_screen()
+	combat_screen._on_combat_ended(GameManager.target_score, true)
+	await wait_process_frames(1)
+
+	var saved := _read_current_save_data()
+	var completed_node_ids: Array[int] = []
+	for id in saved.get("current_run", {}).get("completed_node_ids", []):
+		completed_node_ids.append(int(id))
+	assert_eq(saved.get("phase"), "MAP")
+	assert_eq(saved.get("current_round"), 2)
+	assert_eq(saved.get("coins"), 65)
+	assert_eq(completed_node_ids, [1] as Array[int])
+	assert_true(combat_screen._result_overlay.visible)
+
+
+func test_combat_defeat_result_overlay_deletes_active_run_save() -> void:
+	GameManager.current_run = _build_test_run_state(1)
+	GameManager.current_phase = GameManager.Phase.COMBAT
+	GameManager.last_run_result = {}
+	GameManager.save_game()
+	assert_true(GameManager.can_load_save())
+
+	var combat_screen = await _add_combat_screen()
+	combat_screen._on_combat_ended(12, false)
+	await wait_process_frames(1)
+
+	assert_false(GameManager.has_save())
+	assert_false(GameManager.can_load_save())
+	assert_null(GameManager.current_run)
+	assert_eq_deep(GameManager.last_run_result, {"victory": false, "round": 1, "total_score": 12, "coins": 50})
+	assert_true(combat_screen._result_overlay.visible)
+
+
+func test_combat_boss_victory_overlay_uses_terminal_copy() -> void:
+	GameManager.current_run = _build_boss_start_run_state()
+	GameManager.current_run.enter_node(1)
+	GameManager.current_phase = GameManager.Phase.COMBAT
+	GameManager.current_round = 10
+	GameManager.target_score = 300
+
+	var combat_screen = await _add_combat_screen()
+	combat_screen._show_result_overlay(420, true)
+
+	assert_eq(combat_screen._result_message.text, "BOSS DEFEATED!")
+	assert_eq(combat_screen._result_sub_label.text, "Final target: 300")
+	assert_eq(combat_screen._result_next_btn.text, "FINISH RUN")
+	assert_true(combat_screen._result_next_btn.visible)
+
+
+func test_dice_select_menu_button_abandons_active_run_without_result() -> void:
+	GameManager.current_run = _build_test_run_state(1)
+	GameManager.current_phase = GameManager.Phase.DICE_SELECT
+	GameManager.last_run_result = {}
+	GameManager.save_game()
+	assert_true(GameManager.can_load_save())
+
+	var dice_select = await _add_dice_select_screen()
+	await _press_menu_button(dice_select)
+
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAIN_MENU)
+	assert_eq_deep(GameManager.last_run_result, {})
+	assert_false(GameManager.has_save())
+	assert_false(GameManager.can_load_save())
+
+
+func test_map_menu_button_abandons_active_run_without_result() -> void:
+	GameManager.current_run = _build_test_run_state(1)
+	GameManager.current_phase = GameManager.Phase.MAP
+	GameManager.last_run_result = {}
+	GameManager.save_game()
+	assert_true(GameManager.can_load_save())
+
+	var map_screen = await _add_map_screen()
+	await _press_menu_button(map_screen)
+
+	assert_null(GameManager.current_run)
+	assert_eq(GameManager.current_phase, GameManager.Phase.MAIN_MENU)
+	assert_eq_deep(GameManager.last_run_result, {})
+	assert_false(GameManager.has_save())
+	assert_false(GameManager.can_load_save())
+
+
+func test_enter_boss_map_node_multiplies_target_and_routes_to_dice_select() -> void:
+	var base_target := 200
+	var boss_multiplier := float(DataManager.get_map_config().get("boss_blind_multiplier", 1.5))
+	GameManager.current_run = _build_boss_start_run_state()
+	GameManager.current_phase = GameManager.Phase.MAP
+	GameManager.target_score = base_target
+
+	GameManager.enter_map_node(1)
+
+	assert_eq(GameManager.current_run.current_node_id, 1)
+	assert_eq(GameManager.target_score, int(floor(float(base_target) * boss_multiplier)))
+	assert_eq(GameManager.current_phase, GameManager.Phase.DICE_SELECT)

--- a/tests/integration/test_run_flow.gd.uid
+++ b/tests/integration/test_run_flow.gd.uid
@@ -1,0 +1,1 @@
+uid://bedjdesxjktsj

--- a/tests/smoke/test_boot_smoke.gd
+++ b/tests/smoke/test_boot_smoke.gd
@@ -1,6 +1,11 @@
 extends GutTest
 
 const TestData = preload("res://tests/support/test_data.gd")
+const MAIN_MENU_SCENE := preload("res://scenes/main_menu/main_menu.tscn")
+
+
+func after_each() -> void:
+	GameManager.last_run_result = {}
 
 
 func test_autoloads_boot_with_game_data_loaded() -> void:
@@ -16,12 +21,52 @@ func test_autoloads_boot_with_game_data_loaded() -> void:
 
 
 func test_main_menu_scene_instantiates_with_playtest_button() -> void:
-	var scene: PackedScene = load("res://scenes/main_menu/main_menu.tscn")
-	assert_not_null(scene)
+	assert_not_null(MAIN_MENU_SCENE)
 
-	var menu: Control = add_child_autoqfree(scene.instantiate())
+	var menu: Control = add_child_autoqfree(MAIN_MENU_SCENE.instantiate())
 
 	assert_not_null(menu.get_node("ButtonContainer/PlaytestSurveyButton"))
+
+
+func test_main_menu_shows_last_run_result_overlay_and_continue_clears() -> void:
+	GameManager.last_run_result = {"victory": true, "round": 3, "total_score": 420, "coins": 17}
+	assert_not_null(MAIN_MENU_SCENE)
+
+	var menu: Control = add_child_autoqfree(MAIN_MENU_SCENE.instantiate())
+	await wait_process_frames(1)
+
+	var overlay: Control = menu.find_child("RunResultOverlay", true, false) as Control
+	assert_not_null(overlay)
+	assert_true(_has_label_text(overlay, "VICTORY"))
+	assert_true(_has_label_text(overlay, "ROUND 3"))
+	assert_true(_has_label_text(overlay, "SCORE 420"))
+	assert_true(_has_label_text(overlay, "COINS 17"))
+
+	var continue_btn: Button = menu.find_child("RunResultContinueButton", true, false) as Button
+	assert_not_null(continue_btn)
+	if continue_btn == null:
+		return
+
+	continue_btn.pressed.emit()
+	await wait_process_frames(1)
+
+	assert_eq_deep(GameManager.last_run_result, {})
+	assert_true(not is_instance_valid(overlay) or not overlay.visible)
+
+
+func test_main_menu_shows_defeat_run_result_overlay() -> void:
+	GameManager.last_run_result = {"victory": false, "round": 3, "total_score": 12, "coins": 4}
+	assert_not_null(MAIN_MENU_SCENE)
+
+	var menu: Control = add_child_autoqfree(MAIN_MENU_SCENE.instantiate())
+	await wait_process_frames(1)
+
+	var overlay: Control = menu.find_child("RunResultOverlay", true, false) as Control
+	assert_not_null(overlay)
+	assert_true(_has_label_text(overlay, "DEFEAT"))
+	assert_true(_has_label_text(overlay, "ROUND 3"))
+	assert_true(_has_label_text(overlay, "SCORE 12"))
+	assert_true(_has_label_text(overlay, "COINS 4"))
 
 
 func test_combat_screen_script_loads() -> void:
@@ -69,3 +114,14 @@ func test_seeded_combat_flow_runs_headless() -> void:
 	assert_eq(result["combo"]["type"], "large_straight")
 	assert_eq(result["score_data"]["total"], 160)
 	assert_signal_emitted_with_parameters(manager, "combat_ended", [160, true])
+
+
+func _has_label_text(root: Node, expected: String) -> bool:
+	if root == null:
+		return false
+	if root is Label and (root as Label).text == expected:
+		return true
+	for child in root.get_children():
+		if _has_label_text(child, expected):
+			return true
+	return false

--- a/tests/smoke/test_map_screen_smoke.gd
+++ b/tests/smoke/test_map_screen_smoke.gd
@@ -1,0 +1,157 @@
+extends GutTest
+
+const MapScreenScene := preload("res://scenes/map/map_screen.tscn")
+const MapNodeButtonScene := preload("res://scenes/map/map_node_button.tscn")
+const MapNode := preload("res://scripts/map/map_node.gd")
+const RunState := preload("res://scripts/map/run_state.gd")
+
+
+func before_each() -> void:
+	var combat := MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2] as Array[int])
+	var boss := MapNode.new(2, MapNode.NodeType.BOSS, 2, [] as Array[int])
+	var run := RunState.new()
+	run.nodes = {1: combat, 2: boss}
+	run.current_node_id = -1
+	GameManager.current_run = run
+
+
+func after_each() -> void:
+	GameManager.current_run = null
+
+
+func test_map_screen_instantiates_with_tiny_run() -> void:
+	var map_screen: Control = MapScreenScene.instantiate()
+	add_child_autofree(map_screen)
+	await get_tree().process_frame
+
+	assert_not_null(map_screen)
+	assert_not_null(map_screen.get_node_or_null("%MapContainer"))
+
+
+func test_map_screen_lays_out_path_bottom_to_top() -> void:
+	var map_screen: Control = MapScreenScene.instantiate()
+	add_child_autofree(map_screen)
+	await get_tree().process_frame
+
+	var start_pos: Vector2 = map_screen._position_by_id[map_screen.MAP_START_NODE_ID]
+	var combat_pos: Vector2 = map_screen._position_by_id[1]
+	var boss_pos: Vector2 = map_screen._position_by_id[2]
+	assert_gt(start_pos.y, combat_pos.y)
+	assert_gt(combat_pos.y, boss_pos.y)
+
+
+func test_map_screen_draws_completed_start_combat_at_bottom() -> void:
+	var map_screen: Control = MapScreenScene.instantiate()
+	add_child_autofree(map_screen)
+	await get_tree().process_frame
+
+	var start_button: MapNodeButton = map_screen._button_by_id[map_screen.MAP_START_NODE_ID]
+	var combat_button: MapNodeButton = map_screen._button_by_id[1]
+	assert_eq(start_button.state, "completed")
+	assert_eq(start_button.node_type, MapNode.NodeType.COMBAT)
+	assert_gt(start_button.position.y, combat_button.position.y)
+
+
+func test_map_node_buttons_describe_shop_and_dice_roll_actions() -> void:
+	var button: MapNodeButton = MapNodeButtonScene.instantiate()
+	add_child_autofree(button)
+	await get_tree().process_frame
+
+	button.configure(1, MapNode.NodeType.COMBAT, "available")
+	assert_eq(button.tooltip_text, "Roll Dice")
+	assert_eq(button.get_visible_caption(), "ROLL")
+
+	button.configure(2, MapNode.NodeType.SHOP, "available")
+	assert_eq(button.tooltip_text, "Shop")
+	assert_eq(button.get_visible_caption(), "SHOP")
+
+	button.configure(3, MapNode.NodeType.BOSS, "available")
+	assert_eq(button.tooltip_text, "Boss")
+	assert_eq(button.get_visible_caption(), "BOSS")
+
+
+func test_map_screen_panel_fits_compact_viewport() -> void:
+	var map_screen: Control = MapScreenScene.instantiate()
+	var panel_size: Vector2 = map_screen._target_map_panel_size(Vector2(960, 540))
+	map_screen.free()
+
+	assert_lte(panel_size.x, 896.0)
+	assert_lte(panel_size.y, 324.0)
+
+
+func test_map_screen_keeps_visited_route_completed() -> void:
+	var run := RunState.new()
+	run.nodes = {
+		1: MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2] as Array[int]),
+		2: MapNode.new(2, MapNode.NodeType.SHOP, 2, [] as Array[int]),
+	}
+	run.current_node_id = 2
+	run.visited_node_ids = [1, 2] as Array[int]
+	run.completed_node_ids = [1, 2] as Array[int]
+	GameManager.current_run = run
+	var map_screen: Control = MapScreenScene.instantiate()
+	add_child_autofree(map_screen)
+	await get_tree().process_frame
+
+	assert_eq(map_screen._button_by_id[1].state, "completed")
+
+
+func test_map_screen_uses_scrollable_tall_content_for_full_path() -> void:
+	var nodes := {}
+	for depth in range(1, 7):
+		var next_ids: Array[int] = []
+		if depth < 6:
+			next_ids.append(depth + 1)
+		nodes[depth] = MapNode.new(depth, MapNode.NodeType.COMBAT, depth, next_ids)
+
+	var run := RunState.new()
+	run.nodes = nodes
+	run.current_node_id = -1
+	GameManager.current_run = run
+	var map_screen: Control = MapScreenScene.instantiate()
+	add_child_autofree(map_screen)
+	await get_tree().process_frame
+
+	var visible_size: Vector2 = map_screen._map_scroll.custom_minimum_size
+	assert_gt(map_screen._map_container.custom_minimum_size.y, visible_size.y)
+	assert_gt(map_screen._position_by_id[5].y - map_screen._position_by_id[6].y, 100.0)
+
+
+func test_map_screen_opens_near_next_available_node_after_progress() -> void:
+	var nodes := {}
+	for depth in range(1, 11):
+		var next_ids: Array[int] = []
+		if depth < 10:
+			next_ids.append(depth + 1)
+		nodes[depth] = MapNode.new(depth, MapNode.NodeType.COMBAT, depth, next_ids)
+
+	var run := RunState.new()
+	run.nodes = nodes
+	run.current_node_id = 5
+	run.visited_node_ids = [1, 2, 3, 4, 5] as Array[int]
+	run.completed_node_ids = [1, 2, 3, 4, 5] as Array[int]
+	GameManager.current_run = run
+	var map_screen: Control = MapScreenScene.instantiate()
+	add_child_autofree(map_screen)
+	await wait_process_frames(3)
+
+	var next_node_y: float = map_screen._position_by_id[6].y
+	var visible_top := float(map_screen._map_scroll.scroll_vertical)
+	var visible_bottom: float = visible_top + map_screen._map_scroll.custom_minimum_size.y
+	assert_between(next_node_y, visible_top, visible_bottom)
+
+
+func test_map_screen_keeps_depth_one_child_edges_dim_at_run_start() -> void:
+	var run := RunState.new()
+	run.nodes = {
+		1: MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2] as Array[int]),
+		2: MapNode.new(2, MapNode.NodeType.COMBAT, 2, [] as Array[int]),
+	}
+	run.current_node_id = -1
+	GameManager.current_run = run
+	var map_screen: Control = MapScreenScene.instantiate()
+	add_child_autofree(map_screen)
+	await get_tree().process_frame
+
+	var available := run.available_node_ids()
+	assert_eq(map_screen._edge_color_for(run.nodes[1], 2, run, available), map_screen.EDGE_COLOR_DIM)

--- a/tests/smoke/test_map_screen_smoke.gd.uid
+++ b/tests/smoke/test_map_screen_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://bxqu6g1u0mdb4

--- a/tests/smoke/test_tutorial_e2e.gd
+++ b/tests/smoke/test_tutorial_e2e.gd
@@ -4,6 +4,8 @@ const FLEA_MARKET_SCENE := preload("res://scenes/flea_market/flea_market_screen.
 const DICE_SELECT_SCENE := preload("res://scenes/dice_select/dice_select_screen.tscn")
 const COMBAT_SCENE := preload("res://scenes/combat/combat_screen.tscn")
 const ItemCard = preload("res://scripts/ui/item_card.gd")
+const MapNode = preload("res://scripts/map/map_node.gd")
+const RunState = preload("res://scripts/map/run_state.gd")
 
 
 func before_each() -> void:
@@ -11,6 +13,8 @@ func before_each() -> void:
 	for _i in range(5):
 		GameManager.dice_bag.add_die(Die.new())
 	GameManager.selected_dice.clear()
+	GameManager.current_run = null
+	GameManager.current_phase = GameManager.Phase.MAIN_MENU
 	GameManager.current_round = 1
 	GameManager.target_score = 150
 	GameManager.hands_per_round = 4
@@ -22,6 +26,7 @@ func before_each() -> void:
 
 
 func after_each() -> void:
+	GameManager.current_run = null
 	TutorialManager.completed = false
 	TutorialManager.clear_active_tutorial()
 
@@ -29,6 +34,8 @@ func after_each() -> void:
 func test_tutorial_flow_reaches_completion_end_to_end() -> void:
 	TutorialManager.start_first_run()
 	GameManager._setup_intro_combat()
+	GameManager.current_run = _build_start_run_state()
+	GameManager.current_phase = GameManager.Phase.COMBAT
 
 	var intro_combat: Node = COMBAT_SCENE.instantiate()
 	autoqfree(intro_combat)
@@ -203,6 +210,18 @@ func test_tutorial_flow_reaches_completion_end_to_end() -> void:
 		)
 	)
 	assert_false(combat._menu_btn.disabled)
+	combat._on_combat_ended(GameManager.target_score, true)
+	await wait_process_frames(1)
+	assert_eq(combat._result_next_btn.text, "VIEW MAP")
+	assert_false(combat._result_coins_label.visible)
+	combat._on_next_round_pressed()
+	assert_true(
+		await wait_until(
+			func(): return GameManager.current_phase == GameManager.Phase.MAP, 1.0, 0.05, "tutorial routes to map"
+		)
+	)
+	assert_not_null(GameManager.current_run)
+	assert_eq(GameManager.current_run.current_node_id, -1)
 
 
 func _find_shop_index(items: Array, item_id: String) -> int:
@@ -239,3 +258,13 @@ func _build_selected_dice(selected_indices: Array[int]) -> Array[Die]:
 	for bag_index in selected_indices:
 		selected.append(all_dice[bag_index])
 	return selected
+
+
+func _build_start_run_state() -> RunState:
+	var state := RunState.new()
+	state.nodes = {
+		1: MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2] as Array[int]),
+		2: MapNode.new(2, MapNode.NodeType.BOSS, 2, [] as Array[int]),
+	}
+	state.current_node_id = -1
+	return state

--- a/tests/unit/test_map_generator.gd
+++ b/tests/unit/test_map_generator.gd
@@ -1,0 +1,277 @@
+extends GutTest
+
+
+func test_data_manager_exposes_map_config() -> void:
+	var cfg := DataManager.get_map_config()
+	assert_true(cfg is Dictionary)
+	assert_true(cfg.has("depth"))
+	assert_true(cfg.has("min_nodes_per_level"))
+	assert_true(cfg.has("max_nodes_per_level"))
+	assert_true(cfg.has("shop_probability"))
+	assert_true(cfg.has("max_consecutive_shops"))
+	assert_true(cfg.has("boss_blind_multiplier"))
+
+
+func test_map_config_values_are_sane() -> void:
+	var cfg := DataManager.get_map_config()
+	assert_true(int(cfg["depth"]) >= 2)
+	assert_true(int(cfg["min_nodes_per_level"]) >= 1)
+	assert_true(int(cfg["max_nodes_per_level"]) >= int(cfg["min_nodes_per_level"]))
+	var shop_prob := float(cfg["shop_probability"])
+	assert_true(shop_prob >= 0.0 and shop_prob <= 1.0)
+	assert_true(int(cfg["max_consecutive_shops"]) >= 0)
+	assert_true(float(cfg["boss_blind_multiplier"]) >= 1.0)
+
+
+func test_default_map_depth_is_ten_levels() -> void:
+	var cfg := DataManager.get_map_config()
+	assert_eq(int(cfg["depth"]), 10)
+
+
+func test_invalid_map_config_fallbacks_keep_min_max_consistent() -> void:
+	var cfg := (
+		DataManager
+		. _validated_map_config(
+			{
+				"depth": 1,
+				"min_nodes_per_level": 10,
+				"max_nodes_per_level": 2,
+				"shop_probability": 2.0,
+				"max_consecutive_shops": -1,
+				"boss_blind_multiplier": 0.5,
+			}
+		)
+	)
+	assert_push_error(5)
+	assert_eq(int(cfg["depth"]), 10)
+	assert_true(int(cfg["depth"]) >= 2)
+	assert_eq(int(cfg["min_nodes_per_level"]), 1)
+	assert_eq(int(cfg["max_nodes_per_level"]), 3)
+	var shop_prob := float(cfg["shop_probability"])
+	assert_true(shop_prob >= 0.0 and shop_prob <= 1.0)
+	assert_true(int(cfg["max_consecutive_shops"]) >= 0)
+	assert_true(float(cfg["boss_blind_multiplier"]) >= 1.0)
+
+
+func _generator_script() -> Variant:
+	var script = load("res://scripts/map/map_generator.gd")
+	assert_not_null(script)
+	return script
+
+
+func _generate(seed: int) -> Variant:
+	var script = _generator_script()
+	if script == null:
+		return null
+	return script.generate(seed, DataManager.get_map_config())
+
+
+func _assert_generated(seed: int) -> Variant:
+	var state = _generate(seed)
+	assert_not_null(state)
+	return state
+
+
+func test_generate_returns_run_state() -> void:
+	var state = _assert_generated(12345)
+	if state == null:
+		return
+	assert_eq(state.current_node_id, -1)
+	assert_eq(state.seed, 12345)
+
+
+func test_levels_match_depth() -> void:
+	var cfg := DataManager.get_map_config()
+	var state = _assert_generated(1)
+	if state == null:
+		return
+	var depth: int = int(cfg["depth"])
+	var counts := {}
+	for id_key in state.nodes.keys():
+		var node: MapNode = state.nodes[id_key]
+		counts[node.depth] = int(counts.get(node.depth, 0)) + 1
+	for d in range(1, depth + 1):
+		assert_true(counts.has(d), "missing nodes at depth %d" % d)
+		assert_true(int(counts[d]) >= 1, "no nodes at depth %d" % d)
+
+
+func test_boss_is_unique_at_max_depth() -> void:
+	var cfg := DataManager.get_map_config()
+	var state = _assert_generated(2)
+	if state == null:
+		return
+	var depth: int = int(cfg["depth"])
+	var boss_count := 0
+	for id_key in state.nodes.keys():
+		var node: MapNode = state.nodes[id_key]
+		if node.type == MapNode.NodeType.BOSS:
+			boss_count += 1
+			assert_eq(node.depth, depth)
+			assert_eq(node.next_ids.size(), 0)
+	assert_eq(boss_count, 1)
+
+
+func test_non_boss_nodes_have_one_or_two_outgoing_edges() -> void:
+	var state = _assert_generated(3)
+	if state == null:
+		return
+	for id_key in state.nodes.keys():
+		var node: MapNode = state.nodes[id_key]
+		if node.type != MapNode.NodeType.BOSS:
+			assert_between(node.next_ids.size(), 1, 2, "node %d has %d next_ids" % [node.id, node.next_ids.size()])
+
+
+func test_width_one_level_does_not_fan_out_to_three_children() -> void:
+	var cfg := DataManager.get_map_config()
+	cfg["depth"] = 5
+	cfg["min_nodes_per_level"] = 1
+	cfg["max_nodes_per_level"] = 3
+	cfg["shop_probability"] = 0.0
+	var script = _generator_script()
+	if script == null:
+		return
+	var seed := 4
+	var state = script.generate(seed, cfg)
+	assert_not_null(state)
+	if state == null:
+		return
+	for id_key in state.nodes.keys():
+		var node: MapNode = state.nodes[id_key]
+		if node.type != MapNode.NodeType.BOSS:
+			assert_between(
+				node.next_ids.size(),
+				1,
+				2,
+				"seed %d node %d at depth %d has %d next_ids" % [seed, node.id, node.depth, node.next_ids.size()]
+			)
+
+
+func test_generated_edges_do_not_cross() -> void:
+	var cfg := DataManager.get_map_config()
+	cfg["depth"] = 4
+	cfg["min_nodes_per_level"] = 2
+	cfg["max_nodes_per_level"] = 3
+	cfg["shop_probability"] = 0.5
+	var script = _generator_script()
+	if script == null:
+		return
+	for seed in range(200):
+		var state = script.generate(seed, cfg)
+		assert_not_null(state)
+		if state == null:
+			return
+		_assert_non_crossing_edges(state, seed)
+
+
+func test_all_nodes_reachable_from_start() -> void:
+	var state = _assert_generated(4)
+	if state == null:
+		return
+	var visited := {}
+	var queue: Array[int] = []
+	for id_key in state.nodes.keys():
+		var node: MapNode = state.nodes[id_key]
+		if node.depth == 1:
+			queue.append(node.id)
+			visited[node.id] = true
+	while not queue.is_empty():
+		var cur: int = queue.pop_front()
+		var n: MapNode = state.nodes[cur]
+		for next_id in n.next_ids:
+			if not visited.has(int(next_id)):
+				visited[int(next_id)] = true
+				queue.append(int(next_id))
+	assert_eq(visited.size(), state.nodes.size())
+
+
+func test_determinism_same_seed_same_map() -> void:
+	var a = _assert_generated(777)
+	var b = _assert_generated(777)
+	if a == null or b == null:
+		return
+	assert_eq(a.nodes.size(), b.nodes.size())
+	for id_key in a.nodes.keys():
+		assert_true(b.nodes.has(id_key))
+		var na: MapNode = a.nodes[id_key]
+		var nb: MapNode = b.nodes[id_key]
+		assert_eq(na.type, nb.type)
+		assert_eq(na.depth, nb.depth)
+		var na_next := na.next_ids.duplicate()
+		var nb_next := nb.next_ids.duplicate()
+		na_next.sort()
+		nb_next.sort()
+		assert_eq(na_next, nb_next)
+
+
+func test_no_path_exceeds_max_consecutive_shops() -> void:
+	var cfg := DataManager.get_map_config()
+	cfg["max_consecutive_shops"] = 2
+	cfg["shop_probability"] = 0.95
+	var script = _generator_script()
+	if script == null:
+		return
+	var state = script.generate(98765, cfg)
+	assert_not_null(state)
+	if state == null:
+		return
+	for id_key in state.nodes.keys():
+		var node: MapNode = state.nodes[id_key]
+		if node.depth == 1:
+			_walk(state, node.id, 0, int(cfg["max_consecutive_shops"]))
+
+
+func _walk(state, node_id: int, current_run_count: int, limit: int) -> void:
+	var node: MapNode = state.nodes[node_id]
+	var run_after := 0
+	if node.type == MapNode.NodeType.SHOP:
+		run_after = current_run_count + 1
+	assert_true(run_after <= limit, "shop streak %d exceeds %d at node %d" % [run_after, limit, node_id])
+	for next_id in node.next_ids:
+		_walk(state, int(next_id), run_after, limit)
+
+
+func _assert_non_crossing_edges(state, seed: int) -> void:
+	var levels := {}
+	for id_key in state.nodes.keys():
+		var node: MapNode = state.nodes[id_key]
+		if not levels.has(node.depth):
+			levels[node.depth] = []
+		levels[node.depth].append(node)
+
+	var depths := levels.keys()
+	depths.sort()
+	for depth in depths:
+		if not levels.has(int(depth) + 1):
+			continue
+		var top: Array = levels[depth]
+		var bottom: Array = levels[int(depth) + 1]
+		top.sort_custom(_sort_nodes_by_id)
+		bottom.sort_custom(_sort_nodes_by_id)
+		var bottom_positions := {}
+		for bottom_index in range(bottom.size()):
+			var bottom_node: MapNode = bottom[bottom_index]
+			bottom_positions[bottom_node.id] = bottom_index
+		for left_index in range(top.size()):
+			var left_node: MapNode = top[left_index]
+			for right_index in range(left_index + 1, top.size()):
+				var right_node: MapNode = top[right_index]
+				for left_next_id in left_node.next_ids:
+					for right_next_id in right_node.next_ids:
+						assert_true(
+							int(bottom_positions[int(left_next_id)]) <= int(bottom_positions[int(right_next_id)]),
+							(
+								"crossing edge at seed %d depth %d: %d->%d crosses %d->%d"
+								% [
+									seed,
+									int(depth),
+									left_node.id,
+									int(left_next_id),
+									right_node.id,
+									int(right_next_id),
+								]
+							)
+						)
+
+
+func _sort_nodes_by_id(a: MapNode, b: MapNode) -> bool:
+	return a.id < b.id

--- a/tests/unit/test_map_generator.gd.uid
+++ b/tests/unit/test_map_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://iq3qrue5uhjf

--- a/tests/unit/test_map_node.gd
+++ b/tests/unit/test_map_node.gd
@@ -20,3 +20,11 @@ func test_node_type_values_distinct() -> void:
 func test_default_next_ids_is_empty() -> void:
 	var node := MapNode.new(1, MapNode.NodeType.SHOP, 1)
 	assert_eq(node.next_ids.size(), 0)
+
+
+func test_init_duplicates_next_ids_input() -> void:
+	var original: Array[int] = [5, 6]
+	var node := MapNode.new(1, MapNode.NodeType.COMBAT, 1, original)
+	original[0] = 99
+	original.append(7)
+	assert_eq(node.next_ids, [5, 6] as Array[int])

--- a/tests/unit/test_map_node.gd
+++ b/tests/unit/test_map_node.gd
@@ -1,0 +1,22 @@
+extends GutTest
+
+const MapNode := preload("res://scripts/map/map_node.gd")
+
+
+func test_constructs_with_fields() -> void:
+	var node := MapNode.new(7, MapNode.NodeType.COMBAT, 3, [9, 10] as Array[int])
+	assert_eq(node.id, 7)
+	assert_eq(node.type, MapNode.NodeType.COMBAT)
+	assert_eq(node.depth, 3)
+	assert_eq(node.next_ids, [9, 10] as Array[int])
+
+
+func test_node_type_values_distinct() -> void:
+	assert_ne(MapNode.NodeType.COMBAT, MapNode.NodeType.SHOP)
+	assert_ne(MapNode.NodeType.COMBAT, MapNode.NodeType.BOSS)
+	assert_ne(MapNode.NodeType.SHOP, MapNode.NodeType.BOSS)
+
+
+func test_default_next_ids_is_empty() -> void:
+	var node := MapNode.new(1, MapNode.NodeType.SHOP, 1)
+	assert_eq(node.next_ids.size(), 0)

--- a/tests/unit/test_map_node.gd.uid
+++ b/tests/unit/test_map_node.gd.uid
@@ -1,0 +1,1 @@
+uid://n7cfo4nykro5

--- a/tests/unit/test_run_state.gd
+++ b/tests/unit/test_run_state.gd
@@ -4,7 +4,7 @@ const MapNode := preload("res://scripts/map/map_node.gd")
 const RunState := preload("res://scripts/map/run_state.gd")
 
 
-func _build_state() -> RunState:
+func _build_state():
 	# 3 levels: 1 -> 2 (two nodes) -> boss
 	var n1 := MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2, 3] as Array[int])
 	var n2 := MapNode.new(2, MapNode.NodeType.COMBAT, 2, [4] as Array[int])
@@ -18,34 +18,84 @@ func _build_state() -> RunState:
 
 
 func test_available_at_start_returns_level_one_nodes() -> void:
-	var state := _build_state()
+	var state = _build_state()
 	var ids := state.available_node_ids()
 	ids.sort()
 	assert_eq(ids, [1] as Array[int])
 
 
-func test_available_after_entering_node_returns_next_ids() -> void:
-	var state := _build_state()
-	state.current_node_id = 1
+func test_available_after_completing_node_returns_next_ids() -> void:
+	var state = _build_state()
+	state.enter_node(1)
+	state.complete_current_node()
 	var ids := state.available_node_ids()
 	ids.sort()
 	assert_eq(ids, [2, 3] as Array[int])
 
 
+func test_available_after_entering_uncompleted_node_returns_empty() -> void:
+	var state = _build_state()
+	state.enter_node(1)
+
+	assert_eq(state.available_node_ids().size(), 0)
+
+
 func test_available_at_boss_returns_empty() -> void:
-	var state := _build_state()
+	var state = _build_state()
 	state.current_node_id = 4
 	assert_eq(state.available_node_ids().size(), 0)
 
 
 func test_get_current_node_returns_null_at_start() -> void:
-	var state := _build_state()
-	assert_null(state.get_current_node())
+	var state = _build_state()
+	assert_null(state.call("get_current_node"))
 
 
 func test_get_current_node_returns_node_after_entering() -> void:
-	var state := _build_state()
+	var state = _build_state()
 	state.current_node_id = 2
-	var node: MapNode = state.get_current_node()
+	var node = state.call("get_current_node")
 	assert_not_null(node)
 	assert_eq(node.id, 2)
+
+
+func test_enter_node_records_visited_path_once() -> void:
+	var state = _build_state()
+
+	state.enter_node(1)
+	state.enter_node(2)
+	state.enter_node(2)
+
+	assert_eq(state.current_node_id, 2)
+	assert_eq(state.visited_node_ids, [1, 2] as Array[int])
+	assert_true(state.has_visited(1))
+
+
+func test_complete_current_node_records_completed_path_once() -> void:
+	var state = _build_state()
+
+	state.enter_node(1)
+	state.complete_current_node()
+	state.complete_current_node()
+
+	assert_eq(state.completed_node_ids, [1] as Array[int])
+	assert_true(state.has_completed(1))
+
+
+func test_shop_state_is_saved_per_node_with_defensive_copies() -> void:
+	var state = _build_state()
+	var shop_state := {
+		"offerings": [{"id": "loaded_die"}],
+		"sold": [true],
+		"reroll_count": 1,
+	}
+
+	state.set_shop_state(3, shop_state)
+	shop_state["sold"][0] = false
+
+	var restored: Dictionary = state.get_shop_state(3)
+	assert_eq(restored["offerings"][0]["id"], "loaded_die")
+	assert_eq(restored["sold"], [true])
+	assert_eq(restored["reroll_count"], 1)
+	restored["sold"][0] = false
+	assert_eq(state.get_shop_state(3)["sold"], [true])

--- a/tests/unit/test_run_state.gd
+++ b/tests/unit/test_run_state.gd
@@ -1,0 +1,51 @@
+extends GutTest
+
+const MapNode := preload("res://scripts/map/map_node.gd")
+const RunState := preload("res://scripts/map/run_state.gd")
+
+
+func _build_state() -> RunState:
+	# 3 levels: 1 -> 2 (two nodes) -> boss
+	var n1 := MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2, 3] as Array[int])
+	var n2 := MapNode.new(2, MapNode.NodeType.COMBAT, 2, [4] as Array[int])
+	var n3 := MapNode.new(3, MapNode.NodeType.SHOP, 2, [4] as Array[int])
+	var n4 := MapNode.new(4, MapNode.NodeType.BOSS, 3, [] as Array[int])
+	var state := RunState.new()
+	state.nodes = {1: n1, 2: n2, 3: n3, 4: n4}
+	state.current_node_id = -1
+	state.seed = 42
+	return state
+
+
+func test_available_at_start_returns_level_one_nodes() -> void:
+	var state := _build_state()
+	var ids := state.available_node_ids()
+	ids.sort()
+	assert_eq(ids, [1] as Array[int])
+
+
+func test_available_after_entering_node_returns_next_ids() -> void:
+	var state := _build_state()
+	state.current_node_id = 1
+	var ids := state.available_node_ids()
+	ids.sort()
+	assert_eq(ids, [2, 3] as Array[int])
+
+
+func test_available_at_boss_returns_empty() -> void:
+	var state := _build_state()
+	state.current_node_id = 4
+	assert_eq(state.available_node_ids().size(), 0)
+
+
+func test_get_current_node_returns_null_at_start() -> void:
+	var state := _build_state()
+	assert_null(state.get_current_node())
+
+
+func test_get_current_node_returns_node_after_entering() -> void:
+	var state := _build_state()
+	state.current_node_id = 2
+	var node: MapNode = state.get_current_node()
+	assert_not_null(node)
+	assert_eq(node.id, 2)

--- a/tests/unit/test_run_state.gd.uid
+++ b/tests/unit/test_run_state.gd.uid
@@ -1,0 +1,1 @@
+uid://rosuv26inayw

--- a/tests/unit/test_tutorial_manager.gd
+++ b/tests/unit/test_tutorial_manager.gd
@@ -24,7 +24,7 @@ func test_combat_tutorial_prompts_are_anchored_below_dice() -> void:
 	for step_id in combat_prompt_steps:
 		var config: Dictionary = TutorialManager.STEP_TEXT[step_id]
 		var anchor: Vector2 = config.get("panel_anchor", Vector2.ZERO)
-		assert_ge(anchor.y, 0.82, "%s should render below the dice row" % step_id)
+		assert_true(anchor.y >= 0.82, "%s should render below the dice row" % step_id)
 
 
 func test_fixed_tutorial_shop_uses_current_shop_size() -> void:


### PR DESCRIPTION
## Summary
- Add the generated map/run flow with 10 stages, map UI, clearer node icons/captions, and map scroll positioning.
- Route tutorial, shop, dice select, combat, saves, abandons, victories, and defeats through the new run-aware GameManager flow.
- Add regression coverage for map generation, run saves, tutorial-to-map routing, result overlays, and update architecture docs.

## Test Plan
- make test
- make format-check
- make lint
- make static-check
- git diff --check