### PR TITLE
[codex] Extract run outcome resolver

### DIFF
--- a/knowledge/ARCHITECTURE.md
+++ b/knowledge/ARCHITECTURE.md
@@ -63,10 +63,12 @@ scenes/
 
 scripts/
   autoload/
-    game_manager.gd              # phase routing, run state, save/load, wallet, combat results
+    game_manager.gd              # phase routing, run state, save/load, wallet, scene changes
     data_manager.gd              # JSON loading and validated data access
     tutorial_manager.gd          # tutorial mode, checkpoints, scripted tutorial requirements
     audio_manager.gd             # SFX/music and volume persistence
+  run/
+    run_outcome_resolver.gd      # combat, node completion, and run-end state transitions
   map/
     map_generator.gd             # data-driven route generation
     map_node.gd                  # node id/type/depth/edges
@@ -115,12 +117,12 @@ Primary methods:
 - `start_tutorial_replay()` runs tutorial without keeping the active map run.
 - `skip_active_tutorial()` completes tutorial and creates/routes to a normal map run.
 - `enter_map_node(node_id)` validates availability, marks the current map node, applies boss target scaling when needed, then routes to dice select or flea market.
-- `complete_current_node()` applies combat/shop/boss completion effects and routes to map or run end.
-- `end_combat(final_score, target_beaten)` applies combat result state and immediately changes phase.
-- `resolve_combat_result_for_overlay(final_score, target_beaten)` applies active-run combat result state and writes/deletes the save while the Combat result overlay remains visible.
+- `complete_current_node()` delegates combat/shop/boss completion state to `RunOutcomeResolver`, then routes to map or run end.
+- `end_combat(final_score, target_beaten)` delegates combat result state to `RunOutcomeResolver` and immediately changes phase.
+- `resolve_combat_result_for_overlay(final_score, target_beaten)` delegates active-run combat result state to `RunOutcomeResolver` and writes/deletes the save while the Combat result overlay remains visible.
 - `finish_resolved_combat_result()` changes scene after the player presses the already-resolved result overlay button.
 - `flea_market_continue()` completes shop nodes or falls back to dice select outside runs.
-- `end_run(victory)` sets `last_run_result`, clears `current_run`, deletes the save, and routes to MainMenu.
+- `end_run(victory)` delegates final run result state to `RunOutcomeResolver`, deletes the save, and routes to MainMenu.
 - `abandon_run()` clears the active run without result feedback and deletes the save.
 
 Signals:
@@ -183,6 +185,20 @@ It exposes current-node lookup, enter/complete helpers, availability calculation
 `MapGenerator.generate(seed, config)` builds a run graph from `resources/data/map_config.json`.
 
 The default map is 10 depths. Depth 1 contains initial choices, the final depth contains a boss, and middle depths mix combat/shop nodes while preserving valid forward edges.
+
+### RunOutcomeResolver (`scripts/run/run_outcome_resolver.gd`)
+
+`RunOutcomeResolver` owns deterministic run outcome state transitions that were previously embedded in `GameManager`.
+
+It resolves:
+
+- immediate combat completion from `end_combat`
+- active-run combat result overlays, including idempotent duplicate overlay resolution
+- pending overlay phase routing after the player dismisses the combat result overlay
+- current map node completion, round reward/advance state, and boss victory state
+- terminal victory/defeat result data and active-run cleanup state
+
+The resolver returns save-action metadata to `GameManager`; `GameManager` remains responsible for file IO, scene changes, autoload signals, and platform callbacks.
 
 ## Save And Load
 

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -3,6 +3,7 @@ extends Node
 const RunState := preload("res://scripts/map/run_state.gd")
 const MapGeneratorRef := preload("res://scripts/map/map_generator.gd")
 const MapNodeRef := preload("res://scripts/map/map_node.gd")
+const RunOutcomeResolverRef := preload("res://scripts/run/run_outcome_resolver.gd")
 
 enum Phase { MAIN_MENU, FLEA_MARKET, DICE_SELECT, COMBAT, MAP }
 
@@ -33,7 +34,7 @@ const BASE_TARGET: int = 150
 var save_path: String = SAVE_PATH
 var _last_tutorial_completed: bool = false
 var _last_tutorial_active: bool = false
-var _pending_combat_result_phase: int = -1
+var _run_outcome_resolver := RunOutcomeResolverRef.new()
 
 
 func _ready() -> void:
@@ -201,106 +202,55 @@ func flea_market_continue() -> void:
 
 
 func end_combat(final_score: int, target_beaten: bool) -> void:
-	var destination := _apply_combat_result_state(final_score, target_beaten)
-	_change_phase(destination)
+	PokiSDK.gameplay_stop()
+	var result := _run_outcome_resolver.resolve_combat_result(self, TutorialManager, final_score, target_beaten)
+	_apply_result_events(result)
+	_apply_result_save_action(result)
+	var destination := int(result.get("phase", Phase.MAIN_MENU))
+	_change_phase(destination as Phase)
 
 
 func resolve_combat_result_for_overlay(final_score: int, target_beaten: bool) -> Phase:
-	if _pending_combat_result_phase >= 0:
-		return _pending_combat_result_phase as Phase
-	var destination := _apply_combat_result_state(final_score, target_beaten)
-	_pending_combat_result_phase = destination
-	if destination == Phase.MAIN_MENU:
-		delete_save()
-	else:
-		save_game()
-	return destination
+	var result := _run_outcome_resolver.resolve_combat_result_for_overlay(
+		self, TutorialManager, final_score, target_beaten
+	)
+	if not bool(result.get("already_resolved", false)):
+		PokiSDK.gameplay_stop()
+	_apply_result_events(result)
+	_apply_result_save_action(result)
+	return int(result.get("phase", Phase.MAIN_MENU)) as Phase
 
 
 func finish_resolved_combat_result() -> void:
-	if _pending_combat_result_phase < 0:
+	var destination := _run_outcome_resolver.finish_resolved_combat_result()
+	if destination < 0:
 		return
-	var destination := _pending_combat_result_phase as Phase
-	_pending_combat_result_phase = -1
-	_change_phase(destination)
+	_change_phase(destination as Phase)
 
 
 func has_resolved_combat_result() -> bool:
-	return _pending_combat_result_phase >= 0
+	return _run_outcome_resolver.has_resolved_combat_result()
 
 
 func clear_resolved_combat_result() -> void:
-	_pending_combat_result_phase = -1
-
-
-func _apply_combat_result_state(final_score: int, target_beaten: bool) -> Phase:
-	total_score = final_score
-	score_changed.emit(total_score)
-	PokiSDK.gameplay_stop()
-	if TutorialManager.is_active() and TutorialManager.is_intro_step():
-		if target_beaten:
-			_apply_round_advance()
-			return Phase.FLEA_MARKET
-		return Phase.MAIN_MENU
-	if current_run != null:
-		if current_run.current_node_id == -1:
-			if target_beaten:
-				return Phase.MAP
-			_apply_end_run(false)
-			return Phase.MAIN_MENU
-		if target_beaten:
-			return _apply_current_node_completion_state()
-		_apply_end_run(false)
-		return Phase.MAIN_MENU
-	if target_beaten:
-		_apply_round_advance()
-		return Phase.FLEA_MARKET
-	return Phase.MAIN_MENU
-
-
-func _apply_round_advance() -> void:
-	var reward := 10 + 5 * current_round
-	coins += reward
-	coins_changed.emit(coins)
-	current_round += 1
-	target_score = int(floor(BASE_TARGET * pow(1.5, current_round - 1)))
-	selected_dice.clear()
+	_run_outcome_resolver.clear_resolved_combat_result()
 
 
 func advance_round() -> void:
-	_apply_round_advance()
-	_change_phase(Phase.FLEA_MARKET)
+	var result := _run_outcome_resolver.advance_round(self)
+	_apply_result_events(result)
+	_apply_result_save_action(result)
+	var destination := int(result.get("phase", Phase.FLEA_MARKET))
+	_change_phase(destination as Phase)
 
 
 func complete_current_node() -> void:
-	var destination := _apply_current_node_completion_state()
+	var result := _run_outcome_resolver.complete_current_node(self)
+	_apply_result_events(result)
+	_apply_result_save_action(result)
+	var destination := int(result.get("phase", -1))
 	if destination >= 0:
 		_change_phase(destination as Phase)
-
-
-func _apply_current_node_completion_state() -> int:
-	if current_run == null:
-		push_warning("Cannot complete a map node without an active run.")
-		return -1
-	var node: MapNodeRef = current_run.get_current_node()
-	if node == null:
-		push_warning("Cannot complete a map node before one is selected.")
-		return -1
-	match node.type:
-		MapNodeRef.NodeType.COMBAT:
-			current_run.complete_current_node()
-			_apply_round_advance()
-			return Phase.MAP
-		MapNodeRef.NodeType.SHOP:
-			current_run.complete_current_node()
-			return Phase.MAP
-		MapNodeRef.NodeType.BOSS:
-			current_run.complete_current_node()
-			_apply_round_reward()
-			selected_dice.clear()
-			_apply_end_run(true)
-			return Phase.MAIN_MENU
-	return -1
 
 
 func enter_map_node(node_id: int) -> void:
@@ -324,19 +274,10 @@ func enter_map_node(node_id: int) -> void:
 
 
 func end_run(victory: bool) -> void:
-	_apply_end_run(victory)
+	var result := _run_outcome_resolver.end_run(self, victory)
+	_apply_result_events(result)
+	_apply_result_save_action(result)
 	_change_phase(Phase.MAIN_MENU)
-
-
-func _apply_end_run(victory: bool) -> void:
-	last_run_result = {
-		"victory": victory,
-		"round": current_round,
-		"total_score": total_score,
-		"coins": coins,
-	}
-	current_run = null
-	delete_save()
 
 
 func abandon_run() -> void:
@@ -350,9 +291,23 @@ func get_round_reward() -> int:
 	return 10 + 5 * current_round
 
 
-func _apply_round_reward() -> void:
-	coins += get_round_reward()
-	coins_changed.emit(coins)
+func _apply_result_save_action(result: Dictionary) -> void:
+	match str(result.get("save_action", RunOutcomeResolverRef.SAVE_ACTION_NONE)):
+		RunOutcomeResolverRef.SAVE_ACTION_SAVE:
+			save_game()
+		RunOutcomeResolverRef.SAVE_ACTION_DELETE:
+			delete_save()
+
+
+func _apply_result_events(result: Dictionary) -> void:
+	var events: Variant = result.get("events", {})
+	if not (events is Dictionary):
+		return
+	var event_dict: Dictionary = events
+	if event_dict.has("score_changed"):
+		score_changed.emit(int(event_dict["score_changed"]))
+	if event_dict.has("coins_changed"):
+		coins_changed.emit(int(event_dict["coins_changed"]))
 
 
 func get_app_version() -> String:
@@ -383,7 +338,7 @@ func _change_phase(new_phase: Phase) -> void:
 	phase_changed.emit(new_phase)
 	if new_phase != Phase.MAIN_MENU:
 		save_game()
-	_pending_combat_result_phase = -1
+	clear_resolved_combat_result()
 
 	if new_phase == Phase.MAIN_MENU and old_phase != Phase.MAIN_MENU:
 		AudioManager.pause_for_ad()
@@ -419,8 +374,9 @@ func can_load_save(path_override: String = "") -> bool:
 
 func build_save_data() -> Dictionary:
 	var save_phase := current_phase
-	if _pending_combat_result_phase >= 0:
-		save_phase = _pending_combat_result_phase as Phase
+	var pending_combat_result_phase := _run_outcome_resolver.get_pending_combat_result_phase()
+	if pending_combat_result_phase >= 0:
+		save_phase = pending_combat_result_phase as Phase
 	elif not TutorialManager.is_active():
 		if save_phase == Phase.COMBAT:
 			save_phase = Phase.DICE_SELECT if current_run != null else Phase.FLEA_MARKET

--- a/scripts/run/run_outcome_resolver.gd
+++ b/scripts/run/run_outcome_resolver.gd
@@ -1,0 +1,146 @@
+class_name RunOutcomeResolver
+extends RefCounted
+
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+
+const SAVE_ACTION_NONE := "none"
+const SAVE_ACTION_SAVE := "save"
+const SAVE_ACTION_DELETE := "delete"
+
+var _pending_combat_result_phase: int = -1
+
+
+func resolve_combat_result(manager, tutorial_manager, final_score: int, target_beaten: bool) -> Dictionary:
+	manager.total_score = final_score
+	var events := {"score_changed": manager.total_score}
+
+	if tutorial_manager.is_active() and tutorial_manager.is_intro_step():
+		if target_beaten:
+			events.merge(_apply_round_advance(manager), true)
+			return _outcome(manager.Phase.FLEA_MARKET, SAVE_ACTION_NONE, false, events)
+		return _outcome(manager.Phase.MAIN_MENU, SAVE_ACTION_NONE, false, events)
+
+	if manager.current_run != null:
+		if manager.current_run.current_node_id == -1:
+			if target_beaten:
+				return _outcome(manager.Phase.MAP, SAVE_ACTION_NONE, false, events)
+			return _with_events(_end_run(manager, false), events)
+		if target_beaten:
+			return _with_events(complete_current_node(manager), events)
+		return _with_events(_end_run(manager, false), events)
+
+	if target_beaten:
+		events.merge(_apply_round_advance(manager), true)
+		return _outcome(manager.Phase.FLEA_MARKET, SAVE_ACTION_NONE, false, events)
+	return _outcome(manager.Phase.MAIN_MENU, SAVE_ACTION_NONE, false, events)
+
+
+func resolve_combat_result_for_overlay(manager, tutorial_manager, final_score: int, target_beaten: bool) -> Dictionary:
+	if _pending_combat_result_phase >= 0:
+		return _outcome(_pending_combat_result_phase, SAVE_ACTION_NONE, true)
+
+	var result := resolve_combat_result(manager, tutorial_manager, final_score, target_beaten)
+	var destination := int(result.get("phase", manager.Phase.MAIN_MENU))
+	_pending_combat_result_phase = destination
+	var save_action := SAVE_ACTION_DELETE if destination == manager.Phase.MAIN_MENU else SAVE_ACTION_SAVE
+	result["save_action"] = save_action
+	result["already_resolved"] = false
+	return result
+
+
+func complete_current_node(manager) -> Dictionary:
+	if manager.current_run == null:
+		push_warning("Cannot complete a map node without an active run.")
+		return _outcome(-1)
+	var node: MapNodeRef = manager.current_run.get_current_node()
+	if node == null:
+		push_warning("Cannot complete a map node before one is selected.")
+		return _outcome(-1)
+	match node.type:
+		MapNodeRef.NodeType.COMBAT:
+			manager.current_run.complete_current_node()
+			return _outcome(manager.Phase.MAP, SAVE_ACTION_NONE, false, _apply_round_advance(manager))
+		MapNodeRef.NodeType.SHOP:
+			manager.current_run.complete_current_node()
+			return _outcome(manager.Phase.MAP)
+		MapNodeRef.NodeType.BOSS:
+			manager.current_run.complete_current_node()
+			var events := _apply_round_reward(manager)
+			manager.selected_dice.clear()
+			return _with_events(_end_run(manager, true), events)
+	return _outcome(-1)
+
+
+func end_run(manager, victory: bool) -> Dictionary:
+	return _end_run(manager, victory)
+
+
+func advance_round(manager) -> Dictionary:
+	return _outcome(manager.Phase.FLEA_MARKET, SAVE_ACTION_NONE, false, _apply_round_advance(manager))
+
+
+func finish_resolved_combat_result() -> int:
+	if _pending_combat_result_phase < 0:
+		return -1
+	var destination := _pending_combat_result_phase
+	_pending_combat_result_phase = -1
+	return destination
+
+
+func has_resolved_combat_result() -> bool:
+	return _pending_combat_result_phase >= 0
+
+
+func clear_resolved_combat_result() -> void:
+	_pending_combat_result_phase = -1
+
+
+func get_pending_combat_result_phase() -> int:
+	return _pending_combat_result_phase
+
+
+func _apply_round_advance(manager) -> Dictionary:
+	var events := _apply_round_reward(manager)
+	manager.current_round += 1
+	manager.target_score = int(floor(manager.BASE_TARGET * pow(1.5, manager.current_round - 1)))
+	manager.selected_dice.clear()
+	return events
+
+
+func _apply_round_reward(manager) -> Dictionary:
+	manager.coins += manager.get_round_reward()
+	return {"coins_changed": manager.coins}
+
+
+func _end_run(manager, victory: bool) -> Dictionary:
+	manager.last_run_result = {
+		"victory": victory,
+		"round": manager.current_round,
+		"total_score": manager.total_score,
+		"coins": manager.coins,
+	}
+	manager.current_run = null
+	return _outcome(manager.Phase.MAIN_MENU, SAVE_ACTION_DELETE)
+
+
+func _with_events(result: Dictionary, events: Dictionary) -> Dictionary:
+	if events.is_empty():
+		return result
+	var merged_events := {}
+	var existing_events: Variant = result.get("events", {})
+	if existing_events is Dictionary:
+		merged_events = existing_events.duplicate()
+	merged_events.merge(events, true)
+	result["events"] = merged_events
+	return result
+
+
+func _outcome(
+	phase: int, save_action: String = SAVE_ACTION_NONE, already_resolved: bool = false, events: Dictionary = {}
+) -> Dictionary:
+	var result := {
+		"phase": phase,
+		"save_action": save_action,
+		"already_resolved": already_resolved,
+	}
+	return _with_events(result, events)

--- a/scripts/run/run_outcome_resolver.gd.uid
+++ b/scripts/run/run_outcome_resolver.gd.uid
@@ -1,0 +1,1 @@
+uid://8bwla1o80ol7

--- a/tests/integration/test_game_manager.gd
+++ b/tests/integration/test_game_manager.gd
@@ -154,6 +154,17 @@ func test_end_combat_in_run_victory_routes_through_complete_current_node() -> vo
 	assert_eq(_manager.current_phase, _manager.Phase.MAP)
 
 
+func test_end_combat_emits_score_changed_from_game_manager() -> void:
+	_manager.current_phase = _manager.Phase.COMBAT
+	_manager.current_run = null
+	var final_score: int = _manager.target_score
+	watch_signals(_manager)
+
+	_manager.end_combat(final_score, true)
+
+	assert_signal_emitted_with_parameters(_manager, "score_changed", [final_score])
+
+
 func test_end_combat_completed_tutorial_run_start_goes_to_map() -> void:
 	_manager.current_phase = _manager.Phase.COMBAT
 	_manager.current_run = _build_test_run_state()
@@ -282,6 +293,18 @@ func test_complete_current_node_combat_advances_round_and_goes_to_map() -> void:
 	assert_eq(_manager.target_score, 337)
 	assert_eq(_manager.selected_dice.size(), 0)
 	assert_eq_deep(_manager.phase_history, [_manager.Phase.MAP])
+
+
+func test_complete_current_node_emits_state_change_signals_from_game_manager() -> void:
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.current_node_id = 1
+	_manager.current_round = 2
+	_manager.coins = 10
+	watch_signals(_manager)
+
+	_manager.complete_current_node()
+
+	assert_signal_emitted_with_parameters(_manager, "coins_changed", [30])
 
 
 func test_complete_current_node_shop_goes_to_map_without_round_advance() -> void:

--- a/tests/unit/test_run_outcome_resolver.gd
+++ b/tests/unit/test_run_outcome_resolver.gd
@@ -1,0 +1,170 @@
+extends GutTest
+
+const TestableGameManagerScript = preload("res://tests/support/testable_game_manager.gd")
+const RUN_OUTCOME_RESOLVER_PATH := "res://scripts/run/run_outcome_resolver.gd"
+
+var _manager: Variant
+var _resolver: Variant
+
+
+func before_each() -> void:
+	_manager = TestableGameManagerScript.new()
+	autoqfree(_manager)
+	TutorialManager.completed = false
+	TutorialManager.clear_active_tutorial()
+	_resolver = _make_resolver()
+
+
+func after_each() -> void:
+	TutorialManager.completed = false
+	TutorialManager.clear_active_tutorial()
+
+
+func test_overlay_run_combat_victory_completes_node_once_and_requests_save() -> void:
+	if _resolver == null:
+		return
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_round = 1
+	_manager.coins = 50
+	_manager.target_score = 150
+
+	var result: Dictionary = _resolver.resolve_combat_result_for_overlay(_manager, TutorialManager, 180, true)
+	var duplicate: Dictionary = _resolver.resolve_combat_result_for_overlay(_manager, TutorialManager, 999, true)
+
+	assert_eq(result.get("phase"), _manager.Phase.MAP)
+	assert_eq(result.get("save_action"), _resolver.SAVE_ACTION_SAVE)
+	assert_false(bool(result.get("already_resolved", false)))
+	assert_eq(duplicate.get("phase"), _manager.Phase.MAP)
+	assert_eq(duplicate.get("save_action"), _resolver.SAVE_ACTION_NONE)
+	assert_true(bool(duplicate.get("already_resolved", false)))
+	assert_eq(_manager.total_score, 180)
+	assert_eq(_manager.current_round, 2)
+	assert_eq(_manager.coins, 65)
+	assert_eq(_manager.current_run.completed_node_ids, [1] as Array[int])
+
+
+func test_resolver_returns_state_events_without_emitting_manager_signals() -> void:
+	if _resolver == null:
+		return
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_round = 1
+	_manager.coins = 50
+	watch_signals(_manager)
+
+	var result: Dictionary = _resolver.resolve_combat_result(_manager, TutorialManager, 180, true)
+
+	assert_signal_not_emitted(_manager, "score_changed")
+	assert_signal_not_emitted(_manager, "coins_changed")
+	assert_eq_deep(result.get("events", {}), {"score_changed": 180, "coins_changed": 65})
+
+
+func test_overlay_run_combat_defeat_records_result_and_requests_delete() -> void:
+	if _resolver == null:
+		return
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_round = 2
+	_manager.coins = 17
+
+	var result: Dictionary = _resolver.resolve_combat_result_for_overlay(_manager, TutorialManager, 12, false)
+
+	assert_eq(result.get("phase"), _manager.Phase.MAIN_MENU)
+	assert_eq(result.get("save_action"), _resolver.SAVE_ACTION_DELETE)
+	assert_null(_manager.current_run)
+	assert_eq_deep(
+		_manager.last_run_result,
+		{
+			"victory": false,
+			"round": 2,
+			"total_score": 12,
+			"coins": 17,
+		}
+	)
+
+
+func test_boss_victory_records_terminal_result_and_requests_delete() -> void:
+	if _resolver == null:
+		return
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(4)
+	_manager.current_round = 3
+	_manager.coins = 10
+	_manager.target_score = 200
+
+	var result: Dictionary = _resolver.resolve_combat_result(_manager, TutorialManager, 640, true)
+
+	assert_eq(result.get("phase"), _manager.Phase.MAIN_MENU)
+	assert_eq(result.get("save_action"), _resolver.SAVE_ACTION_DELETE)
+	assert_null(_manager.current_run)
+	assert_eq_deep(
+		_manager.last_run_result,
+		{
+			"victory": true,
+			"round": 3,
+			"total_score": 640,
+			"coins": 35,
+		}
+	)
+	assert_eq(_manager.target_score, 200)
+
+
+func test_tutorial_intro_win_advances_to_flea_market_without_ending_run() -> void:
+	if _resolver == null:
+		return
+	_manager.current_run = _build_test_run_state()
+	_manager.current_round = 0
+	_manager.coins = 25
+	_manager.target_score = 60
+	TutorialManager.start_first_run()
+
+	var result: Dictionary = _resolver.resolve_combat_result(_manager, TutorialManager, 60, true)
+
+	assert_eq(result.get("phase"), _manager.Phase.FLEA_MARKET)
+	assert_eq(result.get("save_action"), _resolver.SAVE_ACTION_NONE)
+	assert_not_null(_manager.current_run)
+	assert_eq(_manager.current_round, 1)
+	assert_eq(_manager.coins, 35)
+	assert_eq(_manager.target_score, _manager.BASE_TARGET)
+	assert_eq_deep(_manager.last_run_result, {})
+
+
+func test_advance_round_uses_resolver_state_transition_and_returns_events() -> void:
+	if _resolver == null:
+		return
+	var selected_dice: Array[Die] = [Die.new()]
+	_manager.current_round = 2
+	_manager.coins = 50
+	_manager.target_score = 200
+	_manager.selected_dice = selected_dice
+
+	var result: Dictionary = _resolver.advance_round(_manager)
+
+	assert_eq(result.get("phase"), _manager.Phase.FLEA_MARKET)
+	assert_eq_deep(result.get("events", {}), {"coins_changed": 70})
+	assert_eq(_manager.coins, 70)
+	assert_eq(_manager.current_round, 3)
+	assert_eq(_manager.target_score, 337)
+	assert_eq(_manager.selected_dice.size(), 0)
+
+
+func _make_resolver() -> Variant:
+	var script: Variant = load(RUN_OUTCOME_RESOLVER_PATH)
+	assert_not_null(script, "RunOutcomeResolver should exist at %s" % RUN_OUTCOME_RESOLVER_PATH)
+	if script == null:
+		return null
+	return script.new()
+
+
+func _build_test_run_state() -> RunState:
+	var state := RunState.new()
+	state.nodes = {
+		1: MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2, 3] as Array[int]),
+		2: MapNode.new(2, MapNode.NodeType.COMBAT, 2, [4] as Array[int]),
+		3: MapNode.new(3, MapNode.NodeType.SHOP, 2, [4] as Array[int]),
+		4: MapNode.new(4, MapNode.NodeType.BOSS, 3, [] as Array[int]),
+	}
+	state.current_node_id = -1
+	state.seed = 42
+	return state

--- a/tests/unit/test_run_outcome_resolver.gd.uid
+++ b/tests/unit/test_run_outcome_resolver.gd.uid
@@ -1,0 +1,1 @@
+uid://cwm8r1eaa86na


### PR DESCRIPTION
## Summary

- Extract deterministic combat/run outcome transitions from `GameManager` into `RunOutcomeResolver`.
- Keep file IO, scene changes, platform callbacks, and autoload signal emission in `GameManager` via resolver-returned `save_action` and `events` metadata.
- Add focused resolver and GameManager tests for overlay idempotency, boss/defeat outcomes, tutorial intro routing, signal boundaries, and delegated round advancement.
- Update `knowledge/ARCHITECTURE.md` for the new `scripts/run/` module and responsibility split.

## Validation

- `make test` passed: 246 tests, 3447 asserts.
- `make static-check` passed.
- `git diff --check` passed.

`make lint` / `make format-check` were not rerun because `gdlint` / `gdformat` are unavailable in this environment.