### PR TITLE
[codex] Extract save data codec

### DIFF
--- a/knowledge/ARCHITECTURE.md
+++ b/knowledge/ARCHITECTURE.md
@@ -63,10 +63,12 @@ scenes/
 
 scripts/
   autoload/
-    game_manager.gd              # phase routing, run state, save/load, wallet, combat results
+    game_manager.gd              # phase routing, run state, save file IO, wallet, combat results
     data_manager.gd              # JSON loading and validated data access
     tutorial_manager.gd          # tutorial mode, checkpoints, scripted tutorial requirements
     audio_manager.gd             # SFX/music and volume persistence
+  save/
+    save_data_codec.gd           # save schema, migration, serialization, and restore state application
   map/
     map_generator.gd             # data-driven route generation
     map_node.gd                  # node id/type/depth/edges
@@ -186,7 +188,9 @@ The default map is 10 depths. Depth 1 contains initial choices, the final depth 
 
 ## Save And Load
 
-`GameManager.build_save_data()` writes format-versioned JSON with player state, tutorial state, and `current_run` when present.
+`GameManager` owns save file IO and load-time phase changes. `SaveDataCodec` owns the save data interface: format versioning, migration, phase normalization, player/run/tutorial serialization, and restoring normalized data back onto `GameManager`/`TutorialManager`.
+
+`GameManager.build_save_data()` delegates to `SaveDataCodec` to produce format-versioned JSON with player state, tutorial state, and `current_run` when present.
 
 Save behavior:
 
@@ -196,7 +200,7 @@ Save behavior:
 - Run victory/defeat and abandon delete the active save so MainMenu cannot continue stale pre-end state.
 - Active-run Combat result overlays resolve state immediately: victory writes the next `MAP`/run-end state before the overlay button is pressed; defeat deletes the save and records defeat result data before the overlay button is pressed.
 
-`GameManager.apply_save_data()` migrates old saves to the current format, restores player/run/tutorial state, and returns the phase to load.
+`GameManager.apply_save_data()` delegates to `SaveDataCodec` to migrate old saves to the current format, restore player/run/tutorial state, and return the phase to load.
 
 ## Core Gameplay Systems
 

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -3,13 +3,14 @@ extends Node
 const RunState := preload("res://scripts/map/run_state.gd")
 const MapGeneratorRef := preload("res://scripts/map/map_generator.gd")
 const MapNodeRef := preload("res://scripts/map/map_node.gd")
+const SaveDataCodecRef := preload("res://scripts/save/save_data_codec.gd")
 
 enum Phase { MAIN_MENU, FLEA_MARKET, DICE_SELECT, COMBAT, MAP }
 
 const SAVE_PATH := "user://save_game.json"
 const APP_VERSION_SETTING := "application/config/version"
 const DEFAULT_APP_VERSION := "v0.0.0"
-const SAVE_FORMAT_VERSION := 2
+const SAVE_FORMAT_VERSION := SaveDataCodecRef.SAVE_FORMAT_VERSION
 const PLAYTEST_SURVEY_URL_SETTING := "playtest/survey_url"
 const STARTING_COINS: int = 10
 
@@ -34,6 +35,7 @@ var save_path: String = SAVE_PATH
 var _last_tutorial_completed: bool = false
 var _last_tutorial_active: bool = false
 var _pending_combat_result_phase: int = -1
+var _save_data_codec := SaveDataCodecRef.new()
 
 
 func _ready() -> void:
@@ -414,71 +416,18 @@ func has_save(path_override: String = "") -> bool:
 
 
 func can_load_save(path_override: String = "") -> bool:
-	return not _normalize_save_data(_read_save_data(path_override)).is_empty()
+	return not _save_data_codec.normalize_save_data(_read_save_data(path_override), get_app_version()).is_empty()
 
 
 func build_save_data() -> Dictionary:
-	var save_phase := current_phase
-	if _pending_combat_result_phase >= 0:
-		save_phase = _pending_combat_result_phase as Phase
-	elif not TutorialManager.is_active():
-		if save_phase == Phase.COMBAT:
-			save_phase = Phase.DICE_SELECT if current_run != null else Phase.FLEA_MARKET
-		elif save_phase == Phase.MAP and current_run == null:
-			save_phase = Phase.FLEA_MARKET
-
-	var data := {
-		"save_version": SAVE_FORMAT_VERSION,
-		"app_version": get_app_version(),
-		"phase": Phase.keys()[save_phase],
-		"coins": coins,
-		"total_score": total_score,
-		"target_score": target_score,
-		"hands_per_round": hands_per_round,
-		"rerolls_per_hand": rerolls_per_hand,
-		"current_round": current_round,
-		"dice_bag": _serialize_dice_bag(),
-		"selected_dice_indices": _serialize_selected_dice_indices(),
-		"modifiers": _serialize_modifiers(),
-		"tutorial_completed": TutorialManager.completed,
-		"tutorial_mode": TutorialManager.mode,
-		"tutorial_step_id": TutorialManager.step_id,
-		"tutorial_state": TutorialManager.build_save_data(),
-	}
-	if current_run != null:
-		data["current_run"] = _serialize_run_state(current_run)
-	return data
+	return _save_data_codec.build_save_data(self, TutorialManager, get_app_version(), _pending_combat_result_phase)
 
 
 func apply_save_data(data: Dictionary) -> Phase:
-	var normalized := _normalize_save_data(data)
-	if normalized.is_empty():
-		return current_phase
-	return _apply_normalized_save_data(normalized)
-
-
-func _apply_normalized_save_data(data: Dictionary) -> Phase:
-	clear_resolved_combat_result()
-	coins = int(data.get("coins", STARTING_COINS))
-	total_score = int(data.get("total_score", 0))
-	target_score = int(data.get("target_score", 150))
-	hands_per_round = int(data.get("hands_per_round", 4))
-	rerolls_per_hand = int(data.get("rerolls_per_hand", 3))
-	current_round = int(data.get("current_round", 1))
-	dice_bag = _deserialize_dice_bag(data.get("dice_bag", []))
-	modifiers = _deserialize_modifiers(data.get("modifiers", []))
-	selected_dice = _deserialize_selected_dice(data.get("selected_dice_indices", []))
-	current_run = _deserialize_run_state(data.get("current_run", {}))
-	last_run_result = {}
-	var tutorial_state: Dictionary = data.get("tutorial_state", {})
-	if tutorial_state.is_empty():
-		tutorial_state = {
-			"completed": bool(data.get("tutorial_completed", false)),
-			"mode": str(data.get("tutorial_mode", TutorialManager.MODE_INACTIVE)),
-			"step_id": str(data.get("tutorial_step_id", "")),
-		}
-	TutorialManager.apply_save_data(tutorial_state)
-	return _phase_from_save_name(str(data.get("phase", "FLEA_MARKET")))
+	var restored_phase := _save_data_codec.apply_save_data(
+		self, TutorialManager, data, current_phase, get_app_version()
+	)
+	return restored_phase as Phase
 
 
 func save_game(path_override: String = "") -> void:
@@ -489,17 +438,17 @@ func save_game(path_override: String = "") -> void:
 
 func load_game(path_override: String = "") -> void:
 	var data := _read_save_data(path_override)
-	var normalized := _normalize_save_data(data)
+	var normalized := _save_data_codec.normalize_save_data(data, get_app_version())
 	if normalized.is_empty():
 		return
-	var phase_to_load := _apply_normalized_save_data(normalized)
+	var phase_to_load := _save_data_codec.apply_normalized_save_data(self, TutorialManager, normalized)
 
 	AudioManager.pause_for_ad()
 	PokiSDK.commercial_break()
 	await PokiSDK.commercial_break_done
 	AudioManager.resume_after_ad()
 
-	_change_phase(phase_to_load)
+	_change_phase(phase_to_load as Phase)
 
 
 func delete_save(path_override: String = "") -> void:
@@ -538,235 +487,3 @@ func _read_save_data(path_override: String = "") -> Dictionary:
 	if raw is Dictionary:
 		return raw.duplicate(true)
 	return {}
-
-
-func _normalize_save_data(data: Dictionary) -> Dictionary:
-	if data.is_empty():
-		return {}
-	return _migrate_save_data(data, _extract_save_version(data))
-
-
-func _extract_save_version(data: Dictionary) -> int:
-	if data.has("save_version"):
-		return int(data.get("save_version", SAVE_FORMAT_VERSION))
-	return 0
-
-
-func _migrate_save_data(data: Dictionary, from_version: int) -> Dictionary:
-	var migrated := data.duplicate(true)
-	if from_version >= 0 and from_version < SAVE_FORMAT_VERSION:
-		migrated["save_version"] = SAVE_FORMAT_VERSION
-		if not migrated.has("app_version"):
-			migrated["app_version"] = "legacy"
-		return migrated
-	if from_version == SAVE_FORMAT_VERSION:
-		if not migrated.has("app_version"):
-			migrated["app_version"] = get_app_version()
-		return migrated
-	return {}
-
-
-func _serialize_dice_bag() -> Array:
-	var dice_arr: Array = []
-	for d in dice_bag.get_all():
-		dice_arr.append(_serialize_die(d))
-	return dice_arr
-
-
-func _serialize_run_state(run: RunState) -> Dictionary:
-	var node_arr: Array = []
-	var node_ids := run.nodes.keys()
-	node_ids.sort()
-	for id_key in node_ids:
-		var node: MapNodeRef = run.nodes[id_key]
-		var serialized_node := {
-			"id": node.id,
-			"type": MapNodeRef.NodeType.keys()[node.type],
-			"depth": node.depth,
-			"next_ids": node.next_ids.duplicate(),
-		}
-		node_arr.append(serialized_node)
-	return {
-		"seed": run.seed,
-		"current_node_id": run.current_node_id,
-		"visited_node_ids": run.visited_node_ids.duplicate(),
-		"completed_node_ids": run.completed_node_ids.duplicate(),
-		"shop_states": _serialize_shop_states(run.shop_states),
-		"nodes": node_arr,
-	}
-
-
-func _deserialize_run_state(raw: Variant) -> RunState:
-	if not (raw is Dictionary):
-		return null
-	var raw_dict: Dictionary = raw
-	var raw_nodes: Variant = raw_dict.get("nodes", [])
-	if not (raw_nodes is Array):
-		return null
-	var run := RunState.new()
-	run.seed = int(raw_dict.get("seed", 0))
-	run.current_node_id = int(raw_dict.get("current_node_id", -1))
-	run.visited_node_ids = _int_array_from_variant(raw_dict.get("visited_node_ids", []))
-	run.completed_node_ids = _int_array_from_variant(raw_dict.get("completed_node_ids", []))
-	run.shop_states = _deserialize_shop_states(raw_dict.get("shop_states", {}))
-	for raw_node in raw_nodes:
-		if not (raw_node is Dictionary):
-			continue
-		var node_dict: Dictionary = raw_node
-		var next_ids := _int_array_from_variant(node_dict.get("next_ids", []))
-		var node := MapNodeRef.new(
-			int(node_dict.get("id", -1)),
-			_map_node_type_from_save(str(node_dict.get("type", "COMBAT"))),
-			int(node_dict.get("depth", 0)),
-			next_ids
-		)
-		if node.id >= 0:
-			run.nodes[node.id] = node
-	if run.nodes.is_empty():
-		return null
-	return run
-
-
-func _serialize_shop_states(shop_states: Dictionary) -> Dictionary:
-	var result := {}
-	for node_id in shop_states.keys():
-		result[str(node_id)] = shop_states[node_id].duplicate(true)
-	return result
-
-
-func _deserialize_shop_states(raw: Variant) -> Dictionary:
-	var result := {}
-	if not (raw is Dictionary):
-		return result
-	var raw_dict: Dictionary = raw
-	for key in raw_dict.keys():
-		if raw_dict[key] is Dictionary:
-			result[int(key)] = raw_dict[key].duplicate(true)
-	return result
-
-
-func _int_array_from_variant(raw: Variant) -> Array[int]:
-	var result: Array[int] = []
-	if raw is Array:
-		for value in raw:
-			result.append(int(value))
-	return result
-
-
-func _map_node_type_from_save(raw_type: String) -> MapNodeRef.NodeType:
-	var type_idx := MapNodeRef.NodeType.keys().find(raw_type)
-	if type_idx < 0:
-		type_idx = MapNodeRef.NodeType.COMBAT
-	return type_idx as MapNodeRef.NodeType
-
-
-func _serialize_selected_dice_indices() -> Array:
-	var used_indices: Array[int] = []
-	var indices: Array = []
-	var all_dice := dice_bag.get_all()
-	for selected_die in selected_dice:
-		for i in range(all_dice.size()):
-			if used_indices.has(i):
-				continue
-			if all_dice[i] == selected_die:
-				indices.append(i)
-				used_indices.append(i)
-				break
-	return indices
-
-
-func _serialize_die(die: Die) -> Dictionary:
-	var face_data: Array = []
-	for f in die.faces:
-		face_data.append(_serialize_face(f))
-	return {
-		"faces": face_data,
-		"color": die.color,
-		"name": die.die_name,
-		"description": die.description,
-		"rarity": die.rarity,
-	}
-
-
-func _serialize_face(face: DiceFace) -> Dictionary:
-	return {
-		"id": face.id,
-		"value": face.value,
-		"face_type": DiceFace.Type.keys()[face.face_type].to_lower(),
-		"effect_value": face.effect_value,
-		"rarity": face.rarity,
-		"cost": face.cost,
-	}
-
-
-func _deserialize_dice_bag(raw_dice: Array) -> DiceBag:
-	var bag := DiceBag.new()
-	for d in raw_dice:
-		if d is Dictionary:
-			bag.add_die(_deserialize_die(d))
-	return bag
-
-
-func _deserialize_selected_dice(raw_indices: Variant) -> Array[Die]:
-	var restored: Array[Die] = []
-	if raw_indices is Array:
-		for raw_index in raw_indices:
-			var die := dice_bag.get_die(int(raw_index))
-			if die != null:
-				restored.append(die)
-	return restored
-
-
-func _serialize_modifiers() -> Array:
-	var arr: Array = []
-	for m in modifiers:
-		arr.append(m.to_save_dict())
-	return arr
-
-
-func _deserialize_modifiers(raw: Variant) -> Array[Modifier]:
-	var result: Array[Modifier] = []
-	if raw is Array:
-		for entry in raw:
-			if entry is Dictionary:
-				var m := Modifier.from_save_dict(entry)
-				if m != null:
-					result.append(m)
-	return result
-
-
-func _deserialize_die(raw_die: Dictionary) -> Die:
-	var die_faces: Array[DiceFace] = []
-	var raw_faces: Array = raw_die.get("faces", [])
-	for f in raw_faces:
-		if f is Dictionary and f.has("face_type"):
-			die_faces.append(_deserialize_face(f))
-		else:
-			die_faces.append(DiceFace.make_basic(int(f)))
-	var die_name_str: String = str(raw_die.get("name", "Basic Die"))
-	var die_desc: String = str(raw_die.get("description", "A standard six-sided die"))
-	var die_rarity: String = str(raw_die.get("rarity", "common"))
-	return Die.new(die_faces, str(raw_die.get("color", "colorless")), die_name_str, die_desc, die_rarity)
-
-
-func _deserialize_face(raw_face: Dictionary) -> DiceFace:
-	return (
-		DiceFace
-		. new(
-			str(raw_face.get("id", "")),
-			int(raw_face.get("value", 0)),
-			DiceFace.type_from_string(str(raw_face.get("face_type", "basic"))),
-			float(raw_face.get("effect_value", 0.0)),
-			str(raw_face.get("rarity", "common")),
-			int(raw_face.get("cost", 0)),
-		)
-	)
-
-
-func _phase_from_save_name(phase_name: String) -> Phase:
-	if phase_name == "MAP" and current_run == null:
-		return Phase.FLEA_MARKET
-	var phase_idx := Phase.keys().find(phase_name)
-	if phase_idx < 0:
-		phase_idx = Phase.FLEA_MARKET
-	return phase_idx as Phase

--- a/scripts/save/save_data_codec.gd
+++ b/scripts/save/save_data_codec.gd
@@ -1,0 +1,309 @@
+class_name SaveDataCodec
+extends RefCounted
+
+const RunStateRef := preload("res://scripts/map/run_state.gd")
+const MapNodeRef := preload("res://scripts/map/map_node.gd")
+
+const SAVE_FORMAT_VERSION := 2
+const DEFAULT_STARTING_COINS := 10
+const DEFAULT_TARGET_SCORE := 150
+const DEFAULT_HANDS_PER_ROUND := 4
+const DEFAULT_REROLLS_PER_HAND := 3
+const DEFAULT_CURRENT_ROUND := 1
+const DEFAULT_LOAD_PHASE := "FLEA_MARKET"
+
+
+func build_save_data(manager, tutorial_manager, app_version: String, pending_combat_result_phase: int) -> Dictionary:
+	var save_phase: int = int(manager.current_phase)
+	if pending_combat_result_phase >= 0:
+		save_phase = pending_combat_result_phase
+	elif not tutorial_manager.is_active():
+		if save_phase == manager.Phase.COMBAT:
+			save_phase = manager.Phase.DICE_SELECT if manager.current_run != null else manager.Phase.FLEA_MARKET
+		elif save_phase == manager.Phase.MAP and manager.current_run == null:
+			save_phase = manager.Phase.FLEA_MARKET
+
+	var data := {
+		"save_version": SAVE_FORMAT_VERSION,
+		"app_version": app_version,
+		"phase": manager.Phase.keys()[save_phase],
+		"coins": manager.coins,
+		"total_score": manager.total_score,
+		"target_score": manager.target_score,
+		"hands_per_round": manager.hands_per_round,
+		"rerolls_per_hand": manager.rerolls_per_hand,
+		"current_round": manager.current_round,
+		"dice_bag": _serialize_dice_bag(manager.dice_bag),
+		"selected_dice_indices": _serialize_selected_dice_indices(manager.dice_bag, manager.selected_dice),
+		"modifiers": _serialize_modifiers(manager.modifiers),
+		"tutorial_completed": tutorial_manager.completed,
+		"tutorial_mode": tutorial_manager.mode,
+		"tutorial_step_id": tutorial_manager.step_id,
+		"tutorial_state": tutorial_manager.build_save_data(),
+	}
+	if manager.current_run != null:
+		data["current_run"] = _serialize_run_state(manager.current_run)
+	return data
+
+
+func apply_save_data(manager, tutorial_manager, data: Dictionary, fallback_phase: int, app_version: String) -> int:
+	var normalized := normalize_save_data(data, app_version)
+	if normalized.is_empty():
+		return fallback_phase
+	return apply_normalized_save_data(manager, tutorial_manager, normalized)
+
+
+func apply_normalized_save_data(manager, tutorial_manager, data: Dictionary) -> int:
+	manager.clear_resolved_combat_result()
+	manager.coins = int(data.get("coins", DEFAULT_STARTING_COINS))
+	manager.total_score = int(data.get("total_score", 0))
+	manager.target_score = int(data.get("target_score", DEFAULT_TARGET_SCORE))
+	manager.hands_per_round = int(data.get("hands_per_round", DEFAULT_HANDS_PER_ROUND))
+	manager.rerolls_per_hand = int(data.get("rerolls_per_hand", DEFAULT_REROLLS_PER_HAND))
+	manager.current_round = int(data.get("current_round", DEFAULT_CURRENT_ROUND))
+	manager.dice_bag = _deserialize_dice_bag(data.get("dice_bag", []))
+	manager.modifiers = _deserialize_modifiers(data.get("modifiers", []))
+	manager.selected_dice = _deserialize_selected_dice(manager.dice_bag, data.get("selected_dice_indices", []))
+	manager.current_run = _deserialize_run_state(data.get("current_run", {}))
+	manager.last_run_result = {}
+	var tutorial_state: Dictionary = data.get("tutorial_state", {})
+	if tutorial_state.is_empty():
+		tutorial_state = {
+			"completed": bool(data.get("tutorial_completed", false)),
+			"mode": str(data.get("tutorial_mode", tutorial_manager.MODE_INACTIVE)),
+			"step_id": str(data.get("tutorial_step_id", "")),
+		}
+	tutorial_manager.apply_save_data(tutorial_state)
+	return _phase_from_save_name(manager, str(data.get("phase", DEFAULT_LOAD_PHASE)))
+
+
+func normalize_save_data(data: Dictionary, app_version: String) -> Dictionary:
+	if data.is_empty():
+		return {}
+	return _migrate_save_data(data, _extract_save_version(data), app_version)
+
+
+func _extract_save_version(data: Dictionary) -> int:
+	if data.has("save_version"):
+		return int(data.get("save_version", SAVE_FORMAT_VERSION))
+	return 0
+
+
+func _migrate_save_data(data: Dictionary, from_version: int, app_version: String) -> Dictionary:
+	var migrated := data.duplicate(true)
+	if from_version >= 0 and from_version < SAVE_FORMAT_VERSION:
+		migrated["save_version"] = SAVE_FORMAT_VERSION
+		if not migrated.has("app_version"):
+			migrated["app_version"] = "legacy"
+		return migrated
+	if from_version == SAVE_FORMAT_VERSION:
+		if not migrated.has("app_version"):
+			migrated["app_version"] = app_version
+		return migrated
+	return {}
+
+
+func _serialize_dice_bag(dice_bag: DiceBag) -> Array:
+	var dice_arr: Array = []
+	for d in dice_bag.get_all():
+		dice_arr.append(_serialize_die(d))
+	return dice_arr
+
+
+func _serialize_run_state(run: RunStateRef) -> Dictionary:
+	var node_arr: Array = []
+	var node_ids := run.nodes.keys()
+	node_ids.sort()
+	for id_key in node_ids:
+		var node: MapNodeRef = run.nodes[id_key]
+		var serialized_node := {
+			"id": node.id,
+			"type": MapNodeRef.NodeType.keys()[node.type],
+			"depth": node.depth,
+			"next_ids": node.next_ids.duplicate(),
+		}
+		node_arr.append(serialized_node)
+	return {
+		"seed": run.seed,
+		"current_node_id": run.current_node_id,
+		"visited_node_ids": run.visited_node_ids.duplicate(),
+		"completed_node_ids": run.completed_node_ids.duplicate(),
+		"shop_states": _serialize_shop_states(run.shop_states),
+		"nodes": node_arr,
+	}
+
+
+func _deserialize_run_state(raw: Variant) -> RunStateRef:
+	if not (raw is Dictionary):
+		return null
+	var raw_dict: Dictionary = raw
+	var raw_nodes: Variant = raw_dict.get("nodes", [])
+	if not (raw_nodes is Array):
+		return null
+	var run := RunStateRef.new()
+	run.seed = int(raw_dict.get("seed", 0))
+	run.current_node_id = int(raw_dict.get("current_node_id", -1))
+	run.visited_node_ids = _int_array_from_variant(raw_dict.get("visited_node_ids", []))
+	run.completed_node_ids = _int_array_from_variant(raw_dict.get("completed_node_ids", []))
+	run.shop_states = _deserialize_shop_states(raw_dict.get("shop_states", {}))
+	for raw_node in raw_nodes:
+		if not (raw_node is Dictionary):
+			continue
+		var node_dict: Dictionary = raw_node
+		var next_ids := _int_array_from_variant(node_dict.get("next_ids", []))
+		var node := MapNodeRef.new(
+			int(node_dict.get("id", -1)),
+			_map_node_type_from_save(str(node_dict.get("type", "COMBAT"))),
+			int(node_dict.get("depth", 0)),
+			next_ids
+		)
+		if node.id >= 0:
+			run.nodes[node.id] = node
+	if run.nodes.is_empty():
+		return null
+	return run
+
+
+func _serialize_shop_states(shop_states: Dictionary) -> Dictionary:
+	var result := {}
+	for node_id in shop_states.keys():
+		result[str(node_id)] = shop_states[node_id].duplicate(true)
+	return result
+
+
+func _deserialize_shop_states(raw: Variant) -> Dictionary:
+	var result := {}
+	if not (raw is Dictionary):
+		return result
+	var raw_dict: Dictionary = raw
+	for key in raw_dict.keys():
+		if raw_dict[key] is Dictionary:
+			result[int(key)] = raw_dict[key].duplicate(true)
+	return result
+
+
+func _int_array_from_variant(raw: Variant) -> Array[int]:
+	var result: Array[int] = []
+	if raw is Array:
+		for value in raw:
+			result.append(int(value))
+	return result
+
+
+func _map_node_type_from_save(raw_type: String) -> MapNodeRef.NodeType:
+	var type_idx := MapNodeRef.NodeType.keys().find(raw_type)
+	if type_idx < 0:
+		type_idx = MapNodeRef.NodeType.COMBAT
+	return type_idx as MapNodeRef.NodeType
+
+
+func _serialize_selected_dice_indices(dice_bag: DiceBag, selected_dice: Array[Die]) -> Array:
+	var used_indices: Array[int] = []
+	var indices: Array = []
+	var all_dice := dice_bag.get_all()
+	for selected_die in selected_dice:
+		for i in range(all_dice.size()):
+			if used_indices.has(i):
+				continue
+			if all_dice[i] == selected_die:
+				indices.append(i)
+				used_indices.append(i)
+				break
+	return indices
+
+
+func _serialize_die(die: Die) -> Dictionary:
+	var face_data: Array = []
+	for f in die.faces:
+		face_data.append(_serialize_face(f))
+	return {
+		"faces": face_data,
+		"color": die.color,
+		"name": die.die_name,
+		"description": die.description,
+		"rarity": die.rarity,
+	}
+
+
+func _serialize_face(face: DiceFace) -> Dictionary:
+	return {
+		"id": face.id,
+		"value": face.value,
+		"face_type": DiceFace.Type.keys()[face.face_type].to_lower(),
+		"effect_value": face.effect_value,
+		"rarity": face.rarity,
+		"cost": face.cost,
+	}
+
+
+func _deserialize_dice_bag(raw_dice: Array) -> DiceBag:
+	var bag := DiceBag.new()
+	for d in raw_dice:
+		if d is Dictionary:
+			bag.add_die(_deserialize_die(d))
+	return bag
+
+
+func _deserialize_selected_dice(dice_bag: DiceBag, raw_indices: Variant) -> Array[Die]:
+	var restored: Array[Die] = []
+	if raw_indices is Array:
+		for raw_index in raw_indices:
+			var die := dice_bag.get_die(int(raw_index))
+			if die != null:
+				restored.append(die)
+	return restored
+
+
+func _serialize_modifiers(modifiers: Array[Modifier]) -> Array:
+	var arr: Array = []
+	for m in modifiers:
+		arr.append(m.to_save_dict())
+	return arr
+
+
+func _deserialize_modifiers(raw: Variant) -> Array[Modifier]:
+	var result: Array[Modifier] = []
+	if raw is Array:
+		for entry in raw:
+			if entry is Dictionary:
+				var m := Modifier.from_save_dict(entry)
+				if m != null:
+					result.append(m)
+	return result
+
+
+func _deserialize_die(raw_die: Dictionary) -> Die:
+	var die_faces: Array[DiceFace] = []
+	var raw_faces: Array = raw_die.get("faces", [])
+	for f in raw_faces:
+		if f is Dictionary and f.has("face_type"):
+			die_faces.append(_deserialize_face(f))
+		else:
+			die_faces.append(DiceFace.make_basic(int(f)))
+	var die_name_str: String = str(raw_die.get("name", "Basic Die"))
+	var die_desc: String = str(raw_die.get("description", "A standard six-sided die"))
+	var die_rarity: String = str(raw_die.get("rarity", "common"))
+	return Die.new(die_faces, str(raw_die.get("color", "colorless")), die_name_str, die_desc, die_rarity)
+
+
+func _deserialize_face(raw_face: Dictionary) -> DiceFace:
+	return (
+		DiceFace
+		. new(
+			str(raw_face.get("id", "")),
+			int(raw_face.get("value", 0)),
+			DiceFace.type_from_string(str(raw_face.get("face_type", "basic"))),
+			float(raw_face.get("effect_value", 0.0)),
+			str(raw_face.get("rarity", "common")),
+			int(raw_face.get("cost", 0)),
+		)
+	)
+
+
+func _phase_from_save_name(manager, phase_name: String) -> int:
+	if phase_name == "MAP" and manager.current_run == null:
+		return manager.Phase.FLEA_MARKET
+	var phase_idx: int = manager.Phase.keys().find(phase_name)
+	if phase_idx < 0:
+		phase_idx = manager.Phase.FLEA_MARKET
+	return phase_idx

--- a/scripts/save/save_data_codec.gd.uid
+++ b/scripts/save/save_data_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://bsepemfonsveu

--- a/tests/unit/test_save_data_codec.gd
+++ b/tests/unit/test_save_data_codec.gd
@@ -1,0 +1,86 @@
+extends GutTest
+
+const SAVE_DATA_CODEC_PATH := "res://scripts/save/save_data_codec.gd"
+const TestData = preload("res://tests/support/test_data.gd")
+const TestableGameManagerScript = preload("res://tests/support/testable_game_manager.gd")
+
+var _manager: Variant
+var _codec: Variant
+
+
+func before_each() -> void:
+	_manager = TestableGameManagerScript.new()
+	autoqfree(_manager)
+	TutorialManager.completed = false
+	TutorialManager.clear_active_tutorial()
+	_codec = _make_codec()
+
+
+func after_each() -> void:
+	TutorialManager.completed = false
+	TutorialManager.clear_active_tutorial()
+
+
+func test_codec_round_trips_player_run_and_tutorial_state_without_file_io() -> void:
+	if _codec == null:
+		return
+	_manager.current_phase = _manager.Phase.DICE_SELECT
+	_manager.coins = 37
+	_manager.total_score = 121
+	_manager.target_score = 275
+	_manager.current_round = 3
+	_manager.dice_bag = DiceBag.new()
+	_manager.dice_bag.add_die(TestData.die_from_values([1, 6, 2, 1, 0, 4]))
+	_manager.modifiers = (
+		[TestData.modifier("x_mult", 3.0, "yahtzee", "yahtzee_hunter", "Yahtzee Hunter")] as Array[Modifier]
+	)
+	_manager.selected_dice = [_manager.dice_bag.get_die(0)] as Array[Die]
+	_manager.current_run = _build_test_run_state()
+	_manager.current_run.enter_node(1)
+	_manager.current_run.complete_current_node()
+	_manager.current_run.enter_node(3)
+	_manager.current_run.set_shop_state(3, {"offerings": [{"id": "loaded_die"}], "sold": [false]})
+	TutorialManager.start_replay()
+	TutorialManager.enter_scene(TutorialManager.SCENE_DICE_SELECT)
+
+	var data: Dictionary = _codec.build_save_data(_manager, TutorialManager, _manager.get_app_version(), -1)
+	var restored: Variant = TestableGameManagerScript.new()
+	autoqfree(restored)
+	var restored_phase: int = _codec.apply_save_data(
+		restored, TutorialManager, data, restored.Phase.MAIN_MENU, restored.get_app_version()
+	)
+
+	assert_eq(restored_phase, restored.Phase.DICE_SELECT)
+	assert_eq(restored.coins, 37)
+	assert_eq(restored.total_score, 121)
+	assert_eq(restored.target_score, 275)
+	assert_eq(restored.current_round, 3)
+	assert_eq(restored.dice_bag.size(), 1)
+	assert_eq(restored.selected_dice.size(), 1)
+	assert_eq(restored.modifiers.size(), 1)
+	assert_not_null(restored.current_run)
+	assert_eq(restored.current_run.current_node_id, 3)
+	assert_eq(restored.current_run.completed_node_ids, [1] as Array[int])
+	assert_eq(restored.current_run.get_shop_state(3)["offerings"][0]["id"], "loaded_die")
+	assert_eq(TutorialManager.mode, TutorialManager.MODE_REPLAY)
+
+
+func _make_codec() -> Variant:
+	var script: Variant = ResourceLoader.load(SAVE_DATA_CODEC_PATH)
+	assert_not_null(script, "SaveDataCodec script should exist")
+	if script == null:
+		return null
+	return script.new()
+
+
+func _build_test_run_state() -> RunState:
+	var state := RunState.new()
+	state.nodes = {
+		1: MapNode.new(1, MapNode.NodeType.COMBAT, 1, [2, 3] as Array[int]),
+		2: MapNode.new(2, MapNode.NodeType.COMBAT, 2, [4] as Array[int]),
+		3: MapNode.new(3, MapNode.NodeType.SHOP, 2, [4] as Array[int]),
+		4: MapNode.new(4, MapNode.NodeType.BOSS, 3, [] as Array[int]),
+	}
+	state.current_node_id = -1
+	state.seed = 42
+	return state

--- a/tests/unit/test_save_data_codec.gd.uid
+++ b/tests/unit/test_save_data_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://2maf0llqr6em


### PR DESCRIPTION
## Summary

- Extract save schema, migration, serialization, and restore-state application into `SaveDataCodec`.
- Keep `GameManager` responsible for save file IO, load-time phase changes, and existing phase/run coordination.
- Add codec-level round-trip coverage and update architecture documentation for the new `scripts/save/` module.

## Validation

- `make static-check` passed
- `make test` passed: 239 tests, 3418 asserts
- `PATH="/tmp/probabimals-dev-venv-313/bin:$PATH" make lint` passed
- `PATH="/tmp/probabimals-dev-venv-313/bin:$PATH" make format-check` passed
- `git diff --check` passed

## Review

- Superpowers code review completed with no Critical, Important, or Minor findings.
