### PR TITLE
[codex] Extract shop purchase resolver

### DIFF
--- a/knowledge/ARCHITECTURE.md
+++ b/knowledge/ARCHITECTURE.md
@@ -85,7 +85,8 @@ scripts/
     combat_dice.gd
     combat_probability_panel.gd
   shop/
-    shop_generator.gd
+    shop_generator.gd             # randomized shop offerings
+    shop_purchase_resolver.gd     # shop item and face-swap purchase outcomes
   ui/
     pixel_bg.gd
     item_card.gd
@@ -227,7 +228,9 @@ Save behavior:
 
 `ShopGenerator` builds randomized offerings from `dice_shop.json`.
 
-`FleaMarketScreen` handles purchases, face swaps, rerolls, tutorial market steps, and persistence of map shop-node state through `RunState.shop_states`.
+`ShopPurchaseResolver` applies item and face-swap purchases to the run wallet, dice bag, modifiers, and reroll count. It returns purchase outcomes so `GameManager` can keep owning state signals such as `coins_changed`.
+
+`FleaMarketScreen` handles shop presentation, face-swap selection UI, rerolls, tutorial market steps, and persistence of map shop-node state through `RunState.shop_states`. Purchase mutation routes through `GameManager`, which delegates item and face-swap rules to `ShopPurchaseResolver`.
 
 ## Scene Trees
 

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -3,6 +3,7 @@ extends Node
 const RunState := preload("res://scripts/map/run_state.gd")
 const MapGeneratorRef := preload("res://scripts/map/map_generator.gd")
 const MapNodeRef := preload("res://scripts/map/map_node.gd")
+const ShopPurchaseResolverRef := preload("res://scripts/shop/shop_purchase_resolver.gd")
 
 enum Phase { MAIN_MENU, FLEA_MARKET, DICE_SELECT, COMBAT, MAP }
 
@@ -34,6 +35,7 @@ var save_path: String = SAVE_PATH
 var _last_tutorial_completed: bool = false
 var _last_tutorial_active: bool = false
 var _pending_combat_result_phase: int = -1
+var _shop_purchase_resolver := ShopPurchaseResolverRef.new()
 
 
 func _ready() -> void:
@@ -115,57 +117,21 @@ func _reset_run_state() -> void:
 
 
 func buy_item(item: Dictionary) -> bool:
-	var cost: int = item.get("cost", 0)
-	if coins < cost:
-		return false
-	var category: String = item.get("category", "")
-	var modifier: Modifier = null
-	if category == "modifier":
-		modifier = Modifier.from_shop_item(item)
-		if modifier == null:
-			return false
-	coins -= cost
-	coins_changed.emit(coins)
-
-	match category:
-		"die":
-			var params = item.get("params", {})
-			var die_color: String = params.get("color", "colorless")
-			var die_name_str: String = item.get("name", "Basic Die")
-			var die_desc: String = item.get("description", "A standard six-sided die")
-			var die_rarity: String = item.get("rarity", "common")
-			if params.has("faces"):
-				var int_faces: Array[int] = []
-				for f in params["faces"]:
-					int_faces.append(int(f))
-				dice_bag.add_die(Die.from_values(int_faces, die_color, die_name_str, die_desc, die_rarity))
-			else:
-				dice_bag.add_die(Die.new([], die_color, die_name_str, die_desc, die_rarity))
-		"face":
-			pass
-		"modifier":
-			if modifier.effect == Modifier.Effect.ADD_REROLLS:
-				rerolls_per_hand += int(modifier.value)
-			else:
-				modifiers.append(modifier)
-	return true
+	var result := _shop_purchase_resolver.purchase_item(self, item)
+	if result.get("coins_changed", false):
+		coins_changed.emit(coins)
+	return result.get("success", false)
 
 
 func buy_face_swap(die_index: int, face_index: int, new_face: DiceFace, cost: int) -> bool:
-	if coins < cost:
-		return false
-	coins -= cost
-	coins_changed.emit(coins)
-	var die := dice_bag.get_die(die_index)
-	if die != null:
-		die.swap_face(face_index, new_face)
-	return true
+	var result := _shop_purchase_resolver.purchase_face_swap(self, die_index, face_index, new_face, cost)
+	if result.get("coins_changed", false):
+		coins_changed.emit(coins)
+	return result.get("success", false)
 
 
 func swap_face(die_index: int, face_index: int, new_face: DiceFace) -> void:
-	var die := dice_bag.get_die(die_index)
-	if die != null:
-		die.swap_face(face_index, new_face)
+	_shop_purchase_resolver.swap_face(self, die_index, face_index, new_face)
 
 
 func go_to_combat() -> void:

--- a/scripts/shop/shop_purchase_resolver.gd
+++ b/scripts/shop/shop_purchase_resolver.gd
@@ -1,0 +1,76 @@
+class_name ShopPurchaseResolver
+extends RefCounted
+
+
+func purchase_item(manager: Variant, item: Dictionary) -> Dictionary:
+	var cost: int = item.get("cost", 0)
+	if manager.coins < cost:
+		return _failure()
+
+	var category: String = item.get("category", "")
+	var modifier: Modifier = null
+	if category == "modifier":
+		modifier = Modifier.from_shop_item(item)
+		if modifier == null:
+			return _failure()
+
+	manager.coins -= cost
+
+	match category:
+		"die":
+			manager.dice_bag.add_die(_die_from_shop_item(item))
+		"face":
+			pass
+		"modifier":
+			_apply_modifier(manager, modifier)
+
+	return _success_with_coin_change()
+
+
+func purchase_face_swap(manager: Variant, die_index: int, face_index: int, new_face: DiceFace, cost: int) -> Dictionary:
+	if manager.coins < cost:
+		return _failure()
+	manager.coins -= cost
+	swap_face(manager, die_index, face_index, new_face)
+	return _success_with_coin_change()
+
+
+func swap_face(manager: Variant, die_index: int, face_index: int, new_face: DiceFace) -> void:
+	var die: Die = manager.dice_bag.get_die(die_index)
+	if die != null:
+		die.swap_face(face_index, new_face)
+
+
+func _die_from_shop_item(item: Dictionary) -> Die:
+	var params: Dictionary = item.get("params", {})
+	var die_color: String = params.get("color", "colorless")
+	var die_name: String = item.get("name", "Basic Die")
+	var die_description: String = item.get("description", "A standard six-sided die")
+	var die_rarity: String = item.get("rarity", "common")
+	if params.has("faces"):
+		var int_faces: Array[int] = []
+		for face in params["faces"]:
+			int_faces.append(int(face))
+		return Die.from_values(int_faces, die_color, die_name, die_description, die_rarity)
+	return Die.new([], die_color, die_name, die_description, die_rarity)
+
+
+func _apply_modifier(manager: Variant, modifier: Modifier) -> void:
+	if modifier.effect == Modifier.Effect.ADD_REROLLS:
+		manager.rerolls_per_hand += int(modifier.value)
+	else:
+		manager.modifiers.append(modifier)
+
+
+func _success_with_coin_change() -> Dictionary:
+	return {
+		"success": true,
+		"coins_changed": true,
+	}
+
+
+func _failure() -> Dictionary:
+	return {
+		"success": false,
+		"coins_changed": false,
+	}

--- a/scripts/shop/shop_purchase_resolver.gd.uid
+++ b/scripts/shop/shop_purchase_resolver.gd.uid
@@ -1,0 +1,1 @@
+uid://dn0okanynnie6

--- a/tests/unit/test_shop_purchase_resolver.gd
+++ b/tests/unit/test_shop_purchase_resolver.gd
@@ -1,0 +1,78 @@
+extends GutTest
+
+const SHOP_PURCHASE_RESOLVER_PATH := "res://scripts/shop/shop_purchase_resolver.gd"
+const TestData = preload("res://tests/support/test_data.gd")
+const TestableGameManagerScript = preload("res://tests/support/testable_game_manager.gd")
+
+var _manager: Variant
+var _resolver: Variant
+
+
+func before_each() -> void:
+	_manager = TestableGameManagerScript.new()
+	autoqfree(_manager)
+	_resolver = _make_resolver()
+
+
+func _make_resolver() -> Variant:
+	var script: GDScript = ResourceLoader.load(SHOP_PURCHASE_RESOLVER_PATH)
+	assert_not_null(script)
+	if script == null:
+		return null
+	return script.new()
+
+
+func test_purchase_catalogue_die_mutates_bag_and_reports_coin_change() -> void:
+	var item: Dictionary = TestData.find_item_by_id(TestData.load_shop_catalogue(), "loaded_die")
+	var starting_size: int = _manager.dice_bag.size()
+	_manager.coins = 50
+
+	var result: Dictionary = _resolver.purchase_item(_manager, item)
+	var bought_die: Die = _manager.dice_bag.get_die(_manager.dice_bag.size() - 1)
+
+	assert_true(result.get("success", false))
+	assert_true(result.get("coins_changed", false))
+	assert_eq(_manager.coins, 25)
+	assert_eq(_manager.dice_bag.size(), starting_size + 1)
+	assert_eq(bought_die.color, "red")
+	assert_eq(bought_die.get("rarity"), "rare")
+	assert_eq_deep(bought_die.get_face_values(), [1, 5, 5, 6, 6, 6])
+
+
+func test_invalid_modifier_purchase_does_not_charge_coins() -> void:
+	_manager.coins = 50
+	var item := {
+		"id": "bad_modifier",
+		"name": "Bad Modifier",
+		"category": "modifier",
+		"cost": 25,
+		"rarity": "common",
+		"params":
+		{
+			"effect": "unknown_effect",
+			"value": 1.0,
+			"condition": "pair",
+		},
+	}
+
+	var result: Dictionary = _resolver.purchase_item(_manager, item)
+
+	assert_false(result.get("success", true))
+	assert_false(result.get("coins_changed", true))
+	assert_eq(_manager.coins, 50)
+	assert_eq(_manager.modifiers.size(), 0)
+	assert_eq(_manager.rerolls_per_hand, 3)
+
+
+func test_purchase_face_swap_replaces_face_and_reports_coin_change() -> void:
+	_manager.coins = 20
+	_manager.dice_bag.add_die(Die.new())
+	var new_face := TestData.basic_face(6)
+	var die: Die = _manager.dice_bag.get_die(0)
+
+	var result: Dictionary = _resolver.purchase_face_swap(_manager, 0, 0, new_face, 7)
+
+	assert_true(result.get("success", false))
+	assert_true(result.get("coins_changed", false))
+	assert_eq(_manager.coins, 13)
+	assert_eq(die.get_face(0).value, 6)

--- a/tests/unit/test_shop_purchase_resolver.gd
+++ b/tests/unit/test_shop_purchase_resolver.gd
@@ -39,6 +39,46 @@ func test_purchase_catalogue_die_mutates_bag_and_reports_coin_change() -> void:
 	assert_eq_deep(bought_die.get_face_values(), [1, 5, 5, 6, 6, 6])
 
 
+func test_purchase_item_rejects_insufficient_coins_without_mutating_bag() -> void:
+	var item: Dictionary = TestData.find_item_by_id(TestData.load_shop_catalogue(), "loaded_die")
+	var starting_size: int = _manager.dice_bag.size()
+	_manager.coins = 24
+
+	var result: Dictionary = _resolver.purchase_item(_manager, item)
+
+	assert_false(result.get("success", true))
+	assert_false(result.get("coins_changed", true))
+	assert_eq(_manager.coins, 24)
+	assert_eq(_manager.dice_bag.size(), starting_size)
+
+
+func test_purchase_scoring_modifier_adds_modifier_and_reports_coin_change() -> void:
+	var item: Dictionary = TestData.find_item_by_id(TestData.load_shop_catalogue(), "pair_boost")
+	_manager.coins = 50
+
+	var result: Dictionary = _resolver.purchase_item(_manager, item)
+
+	assert_true(result.get("success", false))
+	assert_true(result.get("coins_changed", false))
+	assert_eq(_manager.coins, 40)
+	assert_eq(_manager.modifiers.size(), 1)
+	assert_eq(_manager.modifiers[0].effect, Modifier.Effect.ADD_MULT)
+	assert_eq(_manager.modifiers[0].condition, "pair")
+
+
+func test_purchase_reroll_modifier_increases_rerolls_without_adding_modifier() -> void:
+	var item: Dictionary = TestData.find_item_by_id(TestData.load_shop_catalogue(), "reroll_plus")
+	_manager.coins = 50
+
+	var result: Dictionary = _resolver.purchase_item(_manager, item)
+
+	assert_true(result.get("success", false))
+	assert_true(result.get("coins_changed", false))
+	assert_eq(_manager.coins, 25)
+	assert_eq(_manager.rerolls_per_hand, 4)
+	assert_eq(_manager.modifiers.size(), 0)
+
+
 func test_invalid_modifier_purchase_does_not_charge_coins() -> void:
 	_manager.coins = 50
 	var item := {
@@ -76,3 +116,17 @@ func test_purchase_face_swap_replaces_face_and_reports_coin_change() -> void:
 	assert_true(result.get("coins_changed", false))
 	assert_eq(_manager.coins, 13)
 	assert_eq(die.get_face(0).value, 6)
+
+
+func test_purchase_face_swap_rejects_insufficient_coins_without_swapping() -> void:
+	_manager.coins = 6
+	_manager.dice_bag.add_die(Die.new())
+	var new_face := TestData.basic_face(6)
+	var die: Die = _manager.dice_bag.get_die(0)
+
+	var result: Dictionary = _resolver.purchase_face_swap(_manager, 0, 0, new_face, 7)
+
+	assert_false(result.get("success", true))
+	assert_false(result.get("coins_changed", true))
+	assert_eq(_manager.coins, 6)
+	assert_eq(die.get_face(0).value, 1)

--- a/tests/unit/test_shop_purchase_resolver.gd.uid
+++ b/tests/unit/test_shop_purchase_resolver.gd.uid
@@ -1,0 +1,1 @@
+uid://c02g46g6ri4ae


### PR DESCRIPTION
## Summary
- Extract shop item and face-swap purchase mutation into ShopPurchaseResolver
- Keep GameManager as the owner of purchase signals while delegating purchase rules
- Add resolver unit coverage and document the new shop Module

## Validation
- make test
- make static-check
- make lint
- make format-check
- git diff --check