### PR TITLE
[codex] Extract last reroll suspense planner

### DIFF
--- a/knowledge/ARCHITECTURE.md
+++ b/knowledge/ARCHITECTURE.md
@@ -83,6 +83,7 @@ scripts/
   combat/
     combat_manager.gd
     combat_dice.gd
+    last_reroll_suspense_planner.gd # final-reroll suspense timing and reveal-order rules
     combat_probability_panel.gd
   shop/
     shop_generator.gd
@@ -222,6 +223,8 @@ Save behavior:
 - `combat_ended(final_score, target_beaten)`
 
 `CombatScreen` owns presentation, overlays, animation, tutorial gating, and result-overlay navigation. It delegates durable state changes to `GameManager`.
+
+`LastRerollSuspensePlanner` owns the pure final-reroll suspense rules: when suspense applies, which dice remain unrevealed, the randomized reveal order, and stop-delay timing. `CombatScreen` applies that plan to tweens and dice visuals.
 
 ### Shop
 

--- a/scenes/combat/combat_screen.gd
+++ b/scenes/combat/combat_screen.gd
@@ -2,6 +2,7 @@ extends "res://scripts/ui/pixel_bg.gd"
 
 const CombatDice = preload("res://scripts/combat/combat_dice.gd")
 const CombatProbabilityPanelScript = preload("res://scripts/combat/combat_probability_panel.gd")
+const LastRerollSuspensePlannerScript = preload("res://scripts/combat/last_reroll_suspense_planner.gd")
 const ComboRevealFxScript = preload("res://scripts/ui/combo_reveal_fx.gd")
 const ScoreFormat = preload("res://scripts/ui/score_format.gd")
 const TutorialOverlay = preload("res://scripts/ui/tutorial_overlay.gd")
@@ -34,9 +35,6 @@ const COMBAT_SCORE_FLIGHT_FONT_SIZE := 22
 const COMBAT_SCORE_FLIGHT_DURATION := 0.48
 const COMBAT_SCORE_FLIGHT_ARC_HEIGHT := 58.0
 const COMBAT_SCORE_BAR_POP_SCALE := Vector2(1.08, 1.08)
-const COMBAT_LAST_REROLL_STOP_BASE_DELAY := 0.16
-const COMBAT_LAST_REROLL_STOP_EXTRA_DELAY := 0.02
-const COMBAT_LAST_REROLL_MAX_LAST_STOP_DELAY := 0.8
 const COMBAT_LAST_REROLL_POST_REVEAL_DELAY := 0.18
 const COMBAT_LAST_REROLL_FINAL_POP_SCALE := Vector2(1.14, 1.14)
 const COMBAT_LAST_REROLL_NORMAL_POP_SCALE := Vector2(1.08, 1.08)
@@ -138,6 +136,7 @@ var _pause_overlay: ColorRect
 var _animating: bool = false
 var _suspense_reveal_active: bool = false
 var _suspense_final_results: Array[int] = []
+var _suspense_planner := LastRerollSuspensePlannerScript.new()
 var _tutorial_overlay: Control
 var _tutorial_rolls_seen: int = 0
 
@@ -719,32 +718,28 @@ func _count_held_dice() -> int:
 
 
 func _should_use_last_reroll_suspense() -> bool:
-	return combat_mgr != null and combat_mgr.rerolls_remaining == 1 and not _get_unheld_dice_indices().is_empty()
+	return combat_mgr != null and _suspense_planner.should_use(combat_mgr.rerolls_remaining, _held_dice_flags())
 
 
 func _get_unheld_dice_indices() -> Array[int]:
-	var indices: Array[int] = []
+	return _suspense_planner.unheld_indices(_held_dice_flags())
+
+
+func _held_dice_flags() -> Array[bool]:
+	var held_dice: Array[bool] = []
 	if combat_mgr == null:
-		return indices
+		return held_dice
 	for i in range(_dice_cards.size()):
-		if not combat_mgr.is_held(i):
-			indices.append(i)
-	return indices
+		held_dice.append(combat_mgr.is_held(i))
+	return held_dice
 
 
 func _build_last_reroll_stop_delays(indices: Array) -> Array[float]:
-	var delays: Array[float] = []
-	for stop_index in range(indices.size()):
-		var delay := float(stop_index) * COMBAT_LAST_REROLL_STOP_BASE_DELAY
-		delay += float(maxi(stop_index - 1, 0)) * COMBAT_LAST_REROLL_STOP_EXTRA_DELAY
-		delays.append(minf(delay, COMBAT_LAST_REROLL_MAX_LAST_STOP_DELAY))
-	return delays
+	return _suspense_planner.build_stop_delays(indices)
 
 
 func _build_last_reroll_reveal_order(indices: Array[int]) -> Array[int]:
-	var reveal_order := indices.duplicate()
-	reveal_order.shuffle()
-	return reveal_order
+	return _suspense_planner.build_reveal_order(indices)
 
 
 func _begin_suspense_result_buffer() -> void:

--- a/scripts/combat/last_reroll_suspense_planner.gd
+++ b/scripts/combat/last_reroll_suspense_planner.gd
@@ -1,0 +1,33 @@
+class_name LastRerollSuspensePlanner
+extends RefCounted
+
+const STOP_BASE_DELAY := 0.16
+const STOP_EXTRA_DELAY := 0.02
+const MAX_LAST_STOP_DELAY := 0.8
+
+
+func should_use(rerolls_remaining: int, held_dice: Array) -> bool:
+	return rerolls_remaining == 1 and not unheld_indices(held_dice).is_empty()
+
+
+func unheld_indices(held_dice: Array) -> Array[int]:
+	var indices: Array[int] = []
+	for i in range(held_dice.size()):
+		if not bool(held_dice[i]):
+			indices.append(i)
+	return indices
+
+
+func build_stop_delays(indices: Array) -> Array[float]:
+	var delays: Array[float] = []
+	for stop_index in range(indices.size()):
+		var delay := float(stop_index) * STOP_BASE_DELAY
+		delay += float(maxi(stop_index - 1, 0)) * STOP_EXTRA_DELAY
+		delays.append(minf(delay, MAX_LAST_STOP_DELAY))
+	return delays
+
+
+func build_reveal_order(indices: Array[int]) -> Array[int]:
+	var reveal_order := indices.duplicate()
+	reveal_order.shuffle()
+	return reveal_order

--- a/scripts/combat/last_reroll_suspense_planner.gd.uid
+++ b/scripts/combat/last_reroll_suspense_planner.gd.uid
@@ -1,0 +1,1 @@
+uid://boslehv47yqud

--- a/tests/unit/test_last_reroll_suspense_planner.gd
+++ b/tests/unit/test_last_reroll_suspense_planner.gd
@@ -1,0 +1,44 @@
+extends GutTest
+
+const LAST_REROLL_SUSPENSE_PLANNER_PATH := "res://scripts/combat/last_reroll_suspense_planner.gd"
+
+var _planner
+
+
+func before_each() -> void:
+	var script: GDScript = ResourceLoader.load(LAST_REROLL_SUSPENSE_PLANNER_PATH)
+	assert_not_null(script)
+	if script == null:
+		return
+	_planner = script.new()
+
+
+func test_suspense_only_applies_to_final_reroll_with_unheld_dice() -> void:
+	assert_false(_planner.should_use(2, [false, false, false, false, false]))
+	assert_true(_planner.should_use(1, [false, true, true, true, true]))
+	assert_false(_planner.should_use(1, [true, true, true, true, true]))
+	assert_false(_planner.should_use(0, [false, false, false, false, false]))
+
+
+func test_unheld_indices_follow_dice_order() -> void:
+	assert_eq(_planner.unheld_indices([true, false, true, false, false]), [1, 3, 4])
+
+
+func test_stop_delays_escalate_and_cap_before_one_second() -> void:
+	var delays: Array[float] = _planner.build_stop_delays([0, 1, 2, 3, 4])
+
+	assert_eq(delays, [0.0, 0.16, 0.34, 0.52, 0.7])
+	assert_lte(delays[delays.size() - 1], 0.8)
+
+
+func test_reveal_order_is_a_shuffled_copy_of_input_indices() -> void:
+	var ordered_indices: Array[int] = [0, 1, 2, 3, 4]
+	seed(12345)
+
+	var reveal_order: Array[int] = _planner.build_reveal_order(ordered_indices)
+	var sorted_reveal_order := reveal_order.duplicate()
+	sorted_reveal_order.sort()
+
+	assert_eq_deep(sorted_reveal_order, ordered_indices)
+	assert_false(reveal_order == ordered_indices)
+	assert_eq_deep(ordered_indices, [0, 1, 2, 3, 4])

--- a/tests/unit/test_last_reroll_suspense_planner.gd
+++ b/tests/unit/test_last_reroll_suspense_planner.gd
@@ -24,14 +24,21 @@ func test_unheld_indices_follow_dice_order() -> void:
 	assert_eq(_planner.unheld_indices([true, false, true, false, false]), [1, 3, 4])
 
 
-func test_stop_delays_escalate_and_cap_before_one_second() -> void:
+func test_stop_delays_escalate_before_one_second() -> void:
 	var delays: Array[float] = _planner.build_stop_delays([0, 1, 2, 3, 4])
 
 	assert_eq(delays, [0.0, 0.16, 0.34, 0.52, 0.7])
 	assert_lte(delays[delays.size() - 1], 0.8)
 
 
-func test_reveal_order_is_a_shuffled_copy_of_input_indices() -> void:
+func test_stop_delays_cap_long_reveal_sequences() -> void:
+	var delays: Array[float] = _planner.build_stop_delays([0, 1, 2, 3, 4, 5, 6])
+
+	assert_eq(delays[5], 0.8)
+	assert_eq(delays[6], 0.8)
+
+
+func test_reveal_order_is_a_copy_of_input_indices() -> void:
 	var ordered_indices: Array[int] = [0, 1, 2, 3, 4]
 	seed(12345)
 
@@ -40,5 +47,4 @@ func test_reveal_order_is_a_shuffled_copy_of_input_indices() -> void:
 	sorted_reveal_order.sort()
 
 	assert_eq_deep(sorted_reveal_order, ordered_indices)
-	assert_false(reveal_order == ordered_indices)
 	assert_eq_deep(ordered_indices, [0, 1, 2, 3, 4])

--- a/tests/unit/test_last_reroll_suspense_planner.gd.uid
+++ b/tests/unit/test_last_reroll_suspense_planner.gd.uid
@@ -1,0 +1,1 @@
+uid://crbvrcovhqirk


### PR DESCRIPTION
## Summary
- Extract final-reroll suspense planning into LastRerollSuspensePlanner
- Keep CombatScreen responsible for tweening, dice visuals, and result buffering
- Add unit coverage for suspense eligibility, unheld indices, stop delays, and reveal ordering
- Document the new combat Module in the architecture guide

## Validation
- make test
- make static-check
- make lint
- make format-check
- git diff --check
