### PR TITLE
[codex] Extract combat result overlay plan

### DIFF
--- a/knowledge/ARCHITECTURE.md
+++ b/knowledge/ARCHITECTURE.md
@@ -83,6 +83,7 @@ scripts/
   combat/
     combat_manager.gd
     combat_dice.gd
+    combat_result_overlay_plan.gd # pure combat result overlay copy/button visibility rules
     combat_probability_panel.gd
   shop/
     shop_generator.gd
@@ -222,6 +223,8 @@ Save behavior:
 - `combat_ended(final_score, target_beaten)`
 
 `CombatScreen` owns presentation, overlays, animation, tutorial gating, and result-overlay navigation. It delegates durable state changes to `GameManager`.
+
+`CombatResultOverlayPlan` owns pure combat result overlay display rules: victory/defeat copy, reward visibility, and result button visibility. `CombatScreen` applies the plan to Godot controls and keeps animation/audio concerns local to the scene.
 
 ### Shop
 

--- a/scenes/combat/combat_screen.gd
+++ b/scenes/combat/combat_screen.gd
@@ -1,6 +1,7 @@
 extends "res://scripts/ui/pixel_bg.gd"
 
 const CombatDice = preload("res://scripts/combat/combat_dice.gd")
+const CombatResultOverlayPlanScript = preload("res://scripts/combat/combat_result_overlay_plan.gd")
 const CombatProbabilityPanelScript = preload("res://scripts/combat/combat_probability_panel.gd")
 const ComboRevealFxScript = preload("res://scripts/ui/combo_reveal_fx.gd")
 const ScoreFormat = preload("res://scripts/ui/score_format.gd")
@@ -132,6 +133,7 @@ var _result_survey_btn: Button
 var _result_menu_btn: Button
 var _result_final_score: int = 0
 var _result_target_beaten: bool = false
+var _result_overlay_plan := CombatResultOverlayPlanScript.new()
 
 var _pause_overlay: ColorRect
 
@@ -1400,65 +1402,47 @@ func _show_result_overlay(final_score: int, target_beaten: bool) -> void:
 	AudioManager.play_sfx(&"round_win" if target_beaten else &"game_over")
 	_result_survey_btn.disabled = not GameManager.has_playtest_survey_url()
 
-	_result_score_label.text = str(final_score) + " PTS"
-
-	if target_beaten:
-		if _is_current_map_boss_node():
-			_result_message.text = "BOSS DEFEATED!"
-		elif GameManager.current_round == 0:
-			_result_message.text = "ROUND CLEARED!"
-		else:
-			_result_message.text = "ROUND %d CLEARED!" % GameManager.current_round
-		_result_message.add_theme_color_override("font_color", GOLD)
-		if TutorialManager.step_id == TutorialManager.STEP_INTRO_WIN:
-			_result_sub_label.text = "Great start! Now let's head to the Flea Market and upgrade your dice."
-		elif TutorialManager.is_active():
-			_result_sub_label.text = "Great job! You improved your dice, held a strong pair, and turned it into a big combo. You've got the basics down!"
-		elif _is_run_start_map_transition():
-			_result_sub_label.text = "Choose your first route on the map."
-		elif _is_current_map_boss_node():
-			_result_sub_label.text = "Final target: %d" % GameManager.target_score
-		else:
-			_result_sub_label.text = "Target: %d" % GameManager.target_score
-		var reward := GameManager.get_round_reward()
-		_result_coins_label.text = (
-			"[center]+%d%s[/center]" % [reward, SemanticMarkup.coin_icon(COMBAT_RESULT_COINS_FONT_SIZE + 4)]
-		)
-		_result_coins_label.visible = not _is_run_start_map_transition()
-		if _is_run_start_map_transition():
-			_result_next_btn.text = "VIEW MAP"
-		else:
-			_result_next_btn.text = "FINISH RUN" if _is_current_map_boss_node() else "NEXT ROUND"
-		_result_next_btn.visible = true
-		_result_retry_btn.visible = false
-		_result_survey_btn.visible = false
-		_result_menu_btn.visible = false
-	else:
-		if TutorialManager.is_active():
-			_result_message.text = "NOT QUITE!"
-			_result_message.add_theme_color_override("font_color", DIE_COLORS["red"])
-			_result_sub_label.text = "No worries -- give it another shot! The tutorial is here to help you practice."
-			_result_coins_label.visible = false
-			_result_next_btn.visible = false
-			_result_next_btn.text = "NEXT ROUND"
-			_result_retry_btn.visible = true
-			_result_survey_btn.visible = false
-			_result_menu_btn.visible = true
-		else:
-			_result_message.text = "GAME OVER"
-			_result_message.add_theme_color_override("font_color", DIE_COLORS["red"])
-			_result_sub_label.text = "Reached Round %d" % GameManager.current_round
-			_result_coins_label.visible = false
-			_result_next_btn.visible = false
-			_result_next_btn.text = "NEXT ROUND"
-			_result_retry_btn.visible = false
-			_result_survey_btn.visible = true
-			_result_menu_btn.visible = true
+	var plan := _result_overlay_plan.build(final_score, target_beaten, _build_result_overlay_plan_context())
+	_apply_result_overlay_plan(plan)
 
 	var tween := create_tween()
 	tween.set_ease(Tween.EASE_OUT)
 	tween.set_trans(Tween.TRANS_CUBIC)
 	tween.tween_property(_result_overlay, "modulate:a", 1.0, 0.5)
+
+
+func _build_result_overlay_plan_context() -> Dictionary:
+	return {
+		"is_boss": _is_current_map_boss_node(),
+		"is_run_start_map_transition": _is_run_start_map_transition(),
+		"tutorial_active": TutorialManager.is_active(),
+		"tutorial_step_id": TutorialManager.step_id,
+		"intro_win_step_id": TutorialManager.STEP_INTRO_WIN,
+		"current_round": GameManager.current_round,
+		"target_score": GameManager.target_score,
+		"reward": GameManager.get_round_reward(),
+		"coin_icon": SemanticMarkup.coin_icon(COMBAT_RESULT_COINS_FONT_SIZE + 4),
+	}
+
+
+func _apply_result_overlay_plan(plan: Dictionary) -> void:
+	_result_score_label.text = str(plan.get("score_text", ""))
+	_result_message.text = str(plan.get("message", ""))
+	_result_message.add_theme_color_override("font_color", _result_overlay_tone_color(str(plan.get("tone", ""))))
+	_result_sub_label.text = str(plan.get("subtitle", ""))
+	_result_coins_label.text = str(plan.get("coins_text", ""))
+	_result_coins_label.visible = bool(plan.get("coins_visible", false))
+	_result_next_btn.text = str(plan.get("next_text", "NEXT ROUND"))
+	_result_next_btn.visible = bool(plan.get("next_visible", false))
+	_result_retry_btn.visible = bool(plan.get("retry_visible", false))
+	_result_survey_btn.visible = bool(plan.get("survey_visible", false))
+	_result_menu_btn.visible = bool(plan.get("menu_visible", false))
+
+
+func _result_overlay_tone_color(tone: String) -> Color:
+	if tone == CombatResultOverlayPlanScript.TONE_LOSS:
+		return DIE_COLORS["red"]
+	return GOLD
 
 
 func _is_current_map_boss_node() -> bool:

--- a/scripts/combat/combat_result_overlay_plan.gd
+++ b/scripts/combat/combat_result_overlay_plan.gd
@@ -1,0 +1,82 @@
+class_name CombatResultOverlayPlan
+extends RefCounted
+
+const TONE_WIN := "win"
+const TONE_LOSS := "loss"
+
+
+func build(final_score: int, target_beaten: bool, context: Dictionary = {}) -> Dictionary:
+	var result := {
+		"score_text": "%d PTS" % final_score,
+		"next_text": "NEXT ROUND",
+		"next_visible": false,
+		"retry_visible": false,
+		"survey_visible": false,
+		"menu_visible": false,
+		"coins_text": "",
+		"coins_visible": false,
+	}
+
+	if target_beaten:
+		return _build_victory(result, context)
+	return _build_defeat(result, context)
+
+
+func _build_victory(result: Dictionary, context: Dictionary) -> Dictionary:
+	var is_boss := bool(context.get("is_boss", false))
+	var is_run_start := bool(context.get("is_run_start_map_transition", false))
+	var tutorial_active := bool(context.get("tutorial_active", false))
+	var tutorial_step_id := str(context.get("tutorial_step_id", ""))
+	var intro_win_step_id := str(context.get("intro_win_step_id", "intro_win"))
+	var current_round := int(context.get("current_round", 0))
+	var target_score := int(context.get("target_score", 0))
+
+	if is_boss:
+		result["message"] = "BOSS DEFEATED!"
+	elif current_round == 0:
+		result["message"] = "ROUND CLEARED!"
+	else:
+		result["message"] = "ROUND %d CLEARED!" % current_round
+	result["tone"] = TONE_WIN
+
+	if tutorial_step_id == intro_win_step_id:
+		result["subtitle"] = "Great start! Now let's head to the Flea Market and upgrade your dice."
+	elif tutorial_active:
+		result["subtitle"] = (
+			"Great job! You improved your dice, held a strong pair, and turned it into a big combo. "
+			+ "You've got the basics down!"
+		)
+	elif is_run_start:
+		result["subtitle"] = "Choose your first route on the map."
+	elif is_boss:
+		result["subtitle"] = "Final target: %d" % target_score
+	else:
+		result["subtitle"] = "Target: %d" % target_score
+
+	var reward := int(context.get("reward", 0))
+	var coin_icon := str(context.get("coin_icon", ""))
+	result["coins_text"] = "[center]+%d%s[/center]" % [reward, coin_icon]
+	result["coins_visible"] = not is_run_start
+	result["next_text"] = "VIEW MAP" if is_run_start else ("FINISH RUN" if is_boss else "NEXT ROUND")
+	result["next_visible"] = true
+	return result
+
+
+func _build_defeat(result: Dictionary, context: Dictionary) -> Dictionary:
+	var tutorial_active := bool(context.get("tutorial_active", false))
+	var current_round := int(context.get("current_round", 0))
+	result["tone"] = TONE_LOSS
+	result["next_text"] = "NEXT ROUND"
+
+	if tutorial_active:
+		result["message"] = "NOT QUITE!"
+		result["subtitle"] = "No worries -- give it another shot! The tutorial is here to help you practice."
+		result["retry_visible"] = true
+		result["menu_visible"] = true
+		return result
+
+	result["message"] = "GAME OVER"
+	result["subtitle"] = "Reached Round %d" % current_round
+	result["survey_visible"] = true
+	result["menu_visible"] = true
+	return result

--- a/scripts/combat/combat_result_overlay_plan.gd.uid
+++ b/scripts/combat/combat_result_overlay_plan.gd.uid
@@ -1,0 +1,1 @@
+uid://sw0mhm2xhqpk

--- a/tests/unit/test_combat_result_overlay_plan.gd
+++ b/tests/unit/test_combat_result_overlay_plan.gd
@@ -1,0 +1,121 @@
+extends GutTest
+
+const PLAN_PATH := "res://scripts/combat/combat_result_overlay_plan.gd"
+
+var _plan
+
+
+func before_each() -> void:
+	var script := ResourceLoader.load(PLAN_PATH)
+	assert_not_null(script, "CombatResultOverlayPlan script should load")
+	if script != null:
+		_plan = script.new()
+
+
+func test_boss_victory_uses_terminal_copy_and_finish_button() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			420,
+			true,
+			{
+				"is_boss": true,
+				"target_score": 300,
+				"reward": 35,
+				"coin_icon": "[coin]",
+			}
+		)
+	)
+
+	assert_eq(result.get("score_text", ""), "420 PTS")
+	assert_eq(result.get("message", ""), "BOSS DEFEATED!")
+	assert_eq(result.get("subtitle", ""), "Final target: 300")
+	assert_eq(result.get("next_text", ""), "FINISH RUN")
+	assert_true(result.get("next_visible", false))
+	assert_false(result.get("retry_visible", true))
+	assert_false(result.get("survey_visible", true))
+	assert_false(result.get("menu_visible", true))
+
+
+func test_run_start_victory_routes_to_map_without_reward_display() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			60,
+			true,
+			{
+				"is_run_start_map_transition": true,
+				"current_round": 1,
+				"target_score": 150,
+				"reward": 20,
+				"coin_icon": "[coin]",
+			}
+		)
+	)
+
+	assert_eq(result.get("subtitle", ""), "Choose your first route on the map.")
+	assert_eq(result.get("next_text", ""), "VIEW MAP")
+	assert_false(result.get("coins_visible", true))
+
+
+func test_standard_victory_shows_round_reward_and_next_round() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			180,
+			true,
+			{
+				"current_round": 3,
+				"target_score": 250,
+				"reward": 30,
+				"coin_icon": "[coin]",
+			}
+		)
+	)
+
+	assert_eq(result.get("message", ""), "ROUND 3 CLEARED!")
+	assert_eq(result.get("subtitle", ""), "Target: 250")
+	assert_eq(result.get("coins_text", ""), "[center]+30[coin][/center]")
+	assert_true(result.get("coins_visible", false))
+	assert_eq(result.get("next_text", ""), "NEXT ROUND")
+
+
+func test_tutorial_defeat_offers_retry_and_menu_without_survey() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			12,
+			false,
+			{
+				"tutorial_active": true,
+			}
+		)
+	)
+
+	assert_eq(result.get("message", ""), "NOT QUITE!")
+	assert_eq(result.get("tone", ""), "loss")
+	assert_false(result.get("next_visible", true))
+	assert_true(result.get("retry_visible", false))
+	assert_false(result.get("survey_visible", true))
+	assert_true(result.get("menu_visible", false))
+
+
+func test_standard_defeat_shows_game_over_and_survey_option() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			49,
+			false,
+			{
+				"current_round": 4,
+			}
+		)
+	)
+
+	assert_eq(result.get("message", ""), "GAME OVER")
+	assert_eq(result.get("subtitle", ""), "Reached Round 4")
+	assert_eq(result.get("next_text", ""), "NEXT ROUND")
+	assert_false(result.get("next_visible", true))
+	assert_false(result.get("retry_visible", true))
+	assert_true(result.get("survey_visible", false))
+	assert_true(result.get("menu_visible", false))

--- a/tests/unit/test_combat_result_overlay_plan.gd.uid
+++ b/tests/unit/test_combat_result_overlay_plan.gd.uid
@@ -1,0 +1,1 @@
+uid://dn7bynorukocu


### PR DESCRIPTION
## Summary
- Extract pure combat result overlay copy/button/reward visibility decisions into `CombatResultOverlayPlan`
- Keep `CombatScreen` responsible for applying the plan to Godot controls, animation, and audio
- Document the new combat planner in `knowledge/ARCHITECTURE.md`

## Validation
- `make test`
- `make static-check`
- `make lint`
- `make format-check`
- `git diff --check`

Draft PR only; leaving unmerged per request.