### PR TITLE
[codex] Extract main menu run result plan

### DIFF
--- a/knowledge/ARCHITECTURE.md
+++ b/knowledge/ARCHITECTURE.md
@@ -88,6 +88,7 @@ scripts/
     shop_generator.gd
   ui/
     pixel_bg.gd
+    main_menu_run_result_plan.gd # pure MainMenu run result overlay display rules
     item_card.gd
     shop_item_card.gd
     dice_face_panel.gd
@@ -234,6 +235,8 @@ Save behavior:
 ### MainMenu
 
 Control root with pixel background, title, Start/Continue/Settings/Survey/Exit buttons, settings overlay, and run result overlay.
+
+`MainMenuRunResultPlan` owns pure run result overlay display rules: victory/defeat title, summary labels, and continue button copy. `MainMenu` applies the plan to Godot controls and keeps overlay construction local to the scene.
 
 ### Map
 

--- a/scenes/main_menu/main_menu.gd
+++ b/scenes/main_menu/main_menu.gd
@@ -1,5 +1,7 @@
 extends "res://scripts/ui/pixel_bg.gd"
 
+const MainMenuRunResultPlanScript = preload("res://scripts/ui/main_menu_run_result_plan.gd")
+
 const MAIN_MENU_VERSION_FONT_SIZE := 10
 const MAIN_MENU_SETTINGS_PANEL_SIZE := Vector2(480, 0)
 const MAIN_MENU_SETTINGS_PANEL_MARGIN := 32
@@ -45,6 +47,7 @@ var _run_result_overlay: ColorRect
 var _master_slider: HSlider
 var _music_slider: HSlider
 var _sfx_slider: HSlider
+var _run_result_plan := MainMenuRunResultPlanScript.new()
 
 
 func _ready() -> void:
@@ -307,26 +310,29 @@ func _show_run_result_overlay(result: Dictionary) -> void:
 	vbox.add_theme_constant_override("separation", MAIN_MENU_RUN_RESULT_SEPARATION)
 	panel.add_child(vbox)
 
-	var victory := bool(result.get("victory", false))
-	var title_text := "VICTORY" if victory else "DEFEAT"
-	var title_color := GOLD if victory else PINK
-	var title := _make_pixel_label(title_text, MAIN_MENU_RUN_RESULT_TITLE_FONT_SIZE, title_color)
+	var plan := _run_result_plan.build(result)
+	var title := _make_pixel_label(
+		str(plan.get("title_text", "")),
+		MAIN_MENU_RUN_RESULT_TITLE_FONT_SIZE,
+		_run_result_title_color(str(plan.get("title_tone", "")))
+	)
 	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	vbox.add_child(title)
 
 	var round_label := _make_pixel_label(
-		"ROUND %d" % int(result.get("round", 0)), MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE
+		str(plan.get("round_text", "")), MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE
 	)
 	round_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	vbox.add_child(round_label)
 
-	var score := int(result.get("score", result.get("total_score", 0)))
-	var score_label := _make_pixel_label("SCORE %d" % score, MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE)
+	var score_label := _make_pixel_label(
+		str(plan.get("score_text", "")), MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE
+	)
 	score_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	vbox.add_child(score_label)
 
 	var coins_label := _make_pixel_label(
-		"COINS %d" % int(result.get("coins", 0)), MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE
+		str(plan.get("coins_text", "")), MAIN_MENU_RUN_RESULT_LABEL_FONT_SIZE, Color.WHITE
 	)
 	coins_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	vbox.add_child(coins_label)
@@ -335,7 +341,7 @@ func _show_run_result_overlay(result: Dictionary) -> void:
 	vbox.add_child(btn_center)
 
 	var continue_btn := _make_colored_button(
-		"CONTINUE",
+		str(plan.get("button_text", "CONTINUE")),
 		MAIN_MENU_RUN_RESULT_BUTTON_SIZE,
 		GREEN,
 		GREEN.lightened(0.15),
@@ -344,6 +350,12 @@ func _show_run_result_overlay(result: Dictionary) -> void:
 	continue_btn.name = "RunResultContinueButton"
 	continue_btn.pressed.connect(_on_run_result_continue_pressed)
 	btn_center.add_child(continue_btn)
+
+
+func _run_result_title_color(title_tone: String) -> Color:
+	if title_tone == MainMenuRunResultPlanScript.TONE_DEFEAT:
+		return PINK
+	return GOLD
 
 
 func _make_volume_row(parent: VBoxContainer, label_text: String, initial: float) -> HSlider:

--- a/scripts/ui/main_menu_run_result_plan.gd
+++ b/scripts/ui/main_menu_run_result_plan.gd
@@ -1,0 +1,19 @@
+class_name MainMenuRunResultPlan
+extends RefCounted
+
+const TONE_VICTORY := "victory"
+const TONE_DEFEAT := "defeat"
+
+
+func build(result: Dictionary) -> Dictionary:
+	var victory := bool(result.get("victory", false))
+	var score := int(result.get("score", result.get("total_score", 0)))
+
+	return {
+		"title_text": "VICTORY" if victory else "DEFEAT",
+		"title_tone": TONE_VICTORY if victory else TONE_DEFEAT,
+		"round_text": "ROUND %d" % int(result.get("round", 0)),
+		"score_text": "SCORE %d" % score,
+		"coins_text": "COINS %d" % int(result.get("coins", 0)),
+		"button_text": "CONTINUE",
+	}

--- a/scripts/ui/main_menu_run_result_plan.gd.uid
+++ b/scripts/ui/main_menu_run_result_plan.gd.uid
@@ -1,0 +1,1 @@
+uid://cveqesy13ehff

--- a/tests/unit/test_main_menu_run_result_plan.gd
+++ b/tests/unit/test_main_menu_run_result_plan.gd
@@ -1,0 +1,78 @@
+extends GutTest
+
+const PLAN_PATH := "res://scripts/ui/main_menu_run_result_plan.gd"
+
+var _plan
+
+
+func before_each() -> void:
+	var script := ResourceLoader.load(PLAN_PATH)
+	assert_not_null(script, "MainMenuRunResultPlan script should load")
+	if script != null:
+		_plan = script.new()
+
+
+func test_victory_result_uses_victory_copy_and_total_score() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			{
+				"victory": true,
+				"round": 6,
+				"total_score": 420,
+				"coins": 17,
+			}
+		)
+	)
+
+	assert_eq(result.get("title_text", ""), "VICTORY")
+	assert_eq(result.get("title_tone", ""), "victory")
+	assert_eq(result.get("round_text", ""), "ROUND 6")
+	assert_eq(result.get("score_text", ""), "SCORE 420")
+	assert_eq(result.get("coins_text", ""), "COINS 17")
+	assert_eq(result.get("button_text", ""), "CONTINUE")
+
+
+func test_defeat_result_uses_defeat_copy() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			{
+				"victory": false,
+				"round": 3,
+				"total_score": 12,
+				"coins": 4,
+			}
+		)
+	)
+
+	assert_eq(result.get("title_text", ""), "DEFEAT")
+	assert_eq(result.get("title_tone", ""), "defeat")
+	assert_eq(result.get("round_text", ""), "ROUND 3")
+	assert_eq(result.get("score_text", ""), "SCORE 12")
+	assert_eq(result.get("coins_text", ""), "COINS 4")
+
+
+func test_score_field_takes_precedence_over_legacy_total_score() -> void:
+	var result: Dictionary = (
+		_plan
+		. build(
+			{
+				"victory": true,
+				"round": 2,
+				"score": 99,
+				"total_score": 12,
+				"coins": 8,
+			}
+		)
+	)
+
+	assert_eq(result.get("score_text", ""), "SCORE 99")
+
+
+func test_missing_numeric_fields_default_to_zero() -> void:
+	var result: Dictionary = _plan.build({"victory": false})
+
+	assert_eq(result.get("round_text", ""), "ROUND 0")
+	assert_eq(result.get("score_text", ""), "SCORE 0")
+	assert_eq(result.get("coins_text", ""), "COINS 0")

--- a/tests/unit/test_main_menu_run_result_plan.gd.uid
+++ b/tests/unit/test_main_menu_run_result_plan.gd.uid
@@ -1,0 +1,1 @@
+uid://dkq741uuf74ud


### PR DESCRIPTION
## Summary
- Extract pure MainMenu run result overlay display decisions into `MainMenuRunResultPlan`
- Keep `MainMenu` responsible for constructing and styling Godot controls
- Add focused unit tests for victory/defeat/default/score-field behavior
- Document the new UI module in `knowledge/ARCHITECTURE.md`

## Validation
- RED: `./scripts/test/run_gut.sh -gtest=res://tests/unit/test_main_menu_run_result_plan.gd` failed before the module existed
- GREEN: `./scripts/test/run_gut.sh -gtest=res://tests/unit/test_main_menu_run_result_plan.gd -gtest=res://tests/smoke/test_boot_smoke.gd`
- `make test`
- `make static-check`
- `make lint`
- `make format-check`
- `git diff --check`

Draft PR only; leaving unmerged per request.