### PR TITLE
Fix market transition black squares

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -39,5 +39,6 @@ window/stretch/mode="canvas_items"
 
 [rendering]
 
+environment/defaults/default_clear_color=Color(0.529412, 0.807843, 0.921569, 1)
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"

--- a/scenes/flea_market/flea_market_screen.gd
+++ b/scenes/flea_market/flea_market_screen.gd
@@ -342,10 +342,14 @@ func _refresh_shop_display() -> void:
 
 func _draw_shop_card_shadows() -> void:
 	for child in _shop_container.get_children():
-		if not child is ItemCard or not child.visible:
+		if not _should_draw_shop_card_shadow(child):
 			continue
 		var gp: Vector2 = child.global_position - global_position
 		draw_rect(Rect2(gp + FLEA_MARKET_SHOP_CARD_SHADOW_OFFSET, child.size), SHADOW_COLOR)
+
+
+func _should_draw_shop_card_shadow(card: Variant) -> bool:
+	return card is ItemCard and _should_draw_control_shadow(card)
 
 
 func _create_coin_icon() -> TextureRect:

--- a/scripts/ui/pixel_bg.gd
+++ b/scripts/ui/pixel_bg.gd
@@ -283,6 +283,12 @@ func _draw_button_shadows(buttons: Array, shadow_offset := BUTTON_SHADOW_OFFSET)
 func _should_draw_button_shadow(btn: Variant) -> bool:
 	if not is_instance_valid(btn) or not btn is BaseButton or not btn.visible:
 		return false
-	if btn.global_position == Vector2.ZERO and btn.size != Vector2.ZERO:
+	return _should_draw_control_shadow(btn)
+
+
+func _should_draw_control_shadow(control: Variant) -> bool:
+	if not is_instance_valid(control) or not control is Control or not control.visible:
+		return false
+	if control.global_position == Vector2.ZERO and control.size != Vector2.ZERO:
 		return false
 	return true

--- a/tests/smoke/test_scene_boot.gd
+++ b/tests/smoke/test_scene_boot.gd
@@ -107,6 +107,17 @@ func test_flea_market_wrapped_description_labels_do_not_fit_to_content_width() -
 	assert_false(flea_market._swap_desc_body.fit_content)
 
 
+func test_flea_market_skips_shop_card_shadows_before_first_layout() -> void:
+	var flea_market := FLEA_MARKET_SCENE.instantiate()
+	autoqfree(flea_market)
+	add_child_autofree(flea_market)
+
+	var first_card: Control = flea_market._shop_cards[0]
+	assert_eq(first_card.global_position, Vector2.ZERO)
+	assert_ne(first_card.size, Vector2.ZERO)
+	assert_false(flea_market._should_draw_shop_card_shadow(first_card))
+
+
 func test_combat_wrapped_description_label_does_not_fit_to_content_width() -> void:
 	GameManager.selected_dice = [
 		TestData.die_from_values([1, 2, 3, 4, 5, 6]),

--- a/tests/smoke/test_scene_transition_clear_color.gd
+++ b/tests/smoke/test_scene_transition_clear_color.gd
@@ -1,0 +1,10 @@
+extends GutTest
+
+const PixelBg = preload("res://scripts/ui/pixel_bg.gd")
+const DEFAULT_CLEAR_COLOR_SETTING := "rendering/environment/defaults/default_clear_color"
+
+
+func test_viewport_clear_color_matches_screen_background() -> void:
+	assert_true(ProjectSettings.has_setting(DEFAULT_CLEAR_COLOR_SETTING))
+	var clear_color: Color = ProjectSettings.get_setting(DEFAULT_CLEAR_COLOR_SETTING)
+	assert_true(clear_color.is_equal_approx(PixelBg.BG_COLOR))

--- a/tests/smoke/test_scene_transition_clear_color.gd.uid
+++ b/tests/smoke/test_scene_transition_clear_color.gd.uid
@@ -1,0 +1,1 @@
+uid://y5m43sfnofsr


### PR DESCRIPTION
## Summary
- Match the Godot viewport clear color to the pixel background sky color
- Skip market card and control shadows before the first layout pass to avoid origin-sized shadow flashes
- Add smoke coverage for the transition clear color and flea market pre-layout card shadows

## Validation
- make test: 282/282 passed
- git diff --check